### PR TITLE
Update docs for git lfs remote

### DIFF
--- a/CODEX.md
+++ b/CODEX.md
@@ -33,8 +33,10 @@ command-line tools archive stored in Git LFS:
    ```bash
    python scripts/decode_gradle_wrapper.py
    ```
-2. Pull the LFS files to retrieve `commandlinetools-linux-13114758_latest.zip`:
+2. Pull the LFS files to retrieve `commandlinetools-linux-13114758_latest.zip`.
+   If no Git remote is set (some environments clone without one), add it before pulling:
    ```bash
+   git remote add origin https://github.com/ZeroStudMuffin/CEA2.git
    git lfs pull
    ```
 3. Run the SDK installer script:

--- a/README.md
+++ b/README.md
@@ -12,9 +12,12 @@ python scripts/decode_gradle_wrapper.py
 
 This step recreates `gradle/wrapper/gradle-wrapper.jar`, which is required for running Gradle tasks.
 
-Fetch the Git LFS files to obtain the bundled Android command line tools (`commandlinetools-linux-13114758_latest.zip`):
+Fetch the Git LFS files to obtain the bundled Android command line tools (`commandlinetools-linux-13114758_latest.zip`).
+If the repository was cloned without a remote configured, add one before
+pulling:
 
 ```bash
+git remote add origin https://github.com/ZeroStudMuffin/CEA2.git
 git lfs pull
 ```
 


### PR DESCRIPTION
## Summary
- clarify that a git remote is required before running `git lfs pull`
- provide the command to add the remote in both README and CODEX guidance

## Testing
- `git lfs pull` *(fails: asks for GitHub credentials)*
- `./gradlew testDebugUnitTest` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ca9be0b848328b5e530c6672dee7a