### PR TITLE
Disable Robolectric offline mode

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,3 @@
 android.useAndroidX=true
 kotlin.code.style=official
 
-robolectric.offline=true

--- a/robolectric.properties
+++ b/robolectric.properties
@@ -1,2 +1,1 @@
 sdk=34
-robolectric.offline=true


### PR DESCRIPTION
## Summary
- disable `robolectric.offline` in gradle and robolectric properties
- attempted running `lint`, unit tests, and instrumentation tests

Unit tests still fail due to `java.net.SocketException` while trying to fetch Robolectric dependencies; instrumentation tests fail due to no connected device.

## Testing
- `./gradlew lint --no-daemon --console=plain`
- `./gradlew testDebugUnitTest --console=plain --no-daemon` *(fails: network unreachable)*
- `./gradlew connectedDebugAndroidTest --console=plain --no-daemon` *(fails: no connected devices)*

------
https://chatgpt.com/codex/tasks/task_e_686d95427e348328b03775b231186947