### PR TITLE
Clamp slider zoom

### DIFF
--- a/app/src/main/java/com/example/app/BinLocatorActivity.kt
+++ b/app/src/main/java/com/example/app/BinLocatorActivity.kt
@@ -75,7 +75,8 @@ class BinLocatorActivity : AppCompatActivity() {
             previewView.controller = controller
 
             zoomSlider.addOnChangeListener { _, value, _ ->
-                controller.setLinearZoom(value)
+                val clamped = ZoomUtils.clampLinearZoom(value)
+                controller.setLinearZoom(clamped)
             }
 
             zoomResetButton.setOnClickListener {

--- a/app/src/main/java/com/example/app/ZoomUtils.kt
+++ b/app/src/main/java/com/example/app/ZoomUtils.kt
@@ -6,4 +6,14 @@ object ZoomUtils {
      * Ensures the zoom ratio is at least 1x.
      */
     fun clampZoomRatio(ratio: Float): Float = if (ratio < 1f) 1f else ratio
+
+    /**
+     * Clamps a linear zoom value to the valid range of 0–1.
+     */
+    fun clampLinearZoom(value: Float): Float =
+        when {
+            value < 0f -> 0f
+            value > 1f -> 1f
+            else -> value
+        }
 }

--- a/app/src/test/java/com/example/app/ZoomUtilTest.kt
+++ b/app/src/test/java/com/example/app/ZoomUtilTest.kt
@@ -9,4 +9,11 @@ class ZoomUtilTest {
         assertEquals(1f, ZoomUtils.clampZoomRatio(0.5f))
         assertEquals(2f, ZoomUtils.clampZoomRatio(2f))
     }
+
+    @Test
+    fun clampLinearZoom_coercesToRange() {
+        assertEquals(0f, ZoomUtils.clampLinearZoom(-0.1f))
+        assertEquals(1f, ZoomUtils.clampLinearZoom(1.2f))
+        assertEquals(0.5f, ZoomUtils.clampLinearZoom(0.5f))
+    }
 }


### PR DESCRIPTION
## Summary
- clamp slider value before calling `setLinearZoom`
- add `clampLinearZoom` helper
- test linear zoom clamp

## Testing
- `./gradlew lint` *(fails: SDK location not found)*
- `./gradlew testDebugUnitTest` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_686da3ab231c8328a51fd0985f6b4763