### PR TITLE
Implement landscape zoom slider

### DIFF
--- a/AppFeatures.txt
+++ b/AppFeatures.txt
@@ -13,6 +13,7 @@ The project is a minimal Android application written in Kotlin. Below are all of
 * Includes a **Capture** button. When tapped it captures a photo to a temporary file, rotates the image based on the current setting and runs **ML Kit Text Recognition**.
 * Shows a green **TOP** label with a bounding box overlay so users align text correctly. The captured image is cropped to this region before processing.
 * Supports pinch-to-zoom on the preview with a slider and 1x reset button for precise adjustments.
+  In landscape mode the slider turns vertical on the right side with the reset button below it.
 * The recognised text is displayed to the user in a simple alert dialog. Errors are printed to logcat.
 * Limitations:
   * Orientation changes only affect the captured image, not the preview transformation.

--- a/README.md
+++ b/README.md
@@ -79,4 +79,4 @@ This app relies on Material Components. A custom theme extending `Theme.Material
 - Captured images are cropped to this box and processed with ML Kit text
   recognition.
 - Camera preview supports pinch-to-zoom with a slider and a 1x reset button for
-  finer control when capturing text.
+        finer control when capturing text. In landscape orientation, the zoom slider becomes vertical on the right edge with the 1x button positioned beneath it.

--- a/TASK.md
+++ b/TASK.md
@@ -1,0 +1,1 @@
+- [x] Implement vertical zoom slider in landscape mode (2025-08-25)

--- a/app/src/main/res/layout-land/activity_bin_locator.xml
+++ b/app/src/main/res/layout-land/activity_bin_locator.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <FrameLayout
+        android:id="@+id/previewContainer"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent">
+
+        <androidx.camera.view.PreviewView
+            android:id="@+id/viewFinder"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent" />
+
+        <com.example.app.BoundingBoxOverlay
+            android:id="@+id/boundingBox"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent" />
+    </FrameLayout>
+
+    <ImageButton
+        android:id="@+id/rotateButton"
+        android:layout_width="48dp"
+        android:layout_height="48dp"
+        android:layout_margin="8dp"
+        android:background="?attr/selectableItemBackgroundBorderless"
+        android:src="@drawable/ic_rotate"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
+
+    <Button
+        android:id="@+id/captureButton"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Capture"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        android:layout_marginBottom="16dp" />
+
+    <com.google.android.material.slider.Slider
+        android:id="@+id/zoomSlider"
+        android:layout_width="wrap_content"
+        android:layout_height="0dp"
+        android:valueFrom="0"
+        android:valueTo="1"
+        android:orientation="vertical"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toTopOf="@id/zoomResetButton"
+        app:layout_constraintEnd_toEndOf="parent"
+        android:layout_marginTop="16dp"
+        android:layout_marginEnd="16dp"
+        android:layout_marginBottom="8dp" />
+
+    <Button
+        android:id="@+id/zoomResetButton"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="1x"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        android:layout_marginEnd="16dp"
+        android:layout_marginBottom="16dp" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/test/java/com/example/app/LayoutOrientationTest.kt
+++ b/app/src/test/java/com/example/app/LayoutOrientationTest.kt
@@ -1,0 +1,14 @@
+package com.example.app
+
+import java.io.File
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class LayoutOrientationTest {
+    @Test
+    fun landscapeLayout_hasVerticalSlider() {
+        val path = "src/main/res/layout-land/activity_bin_locator.xml"
+        val text = File(path).readText()
+        assertTrue(text.contains("orientation=\"vertical\""))
+    }
+}


### PR DESCRIPTION
## Summary
- add layout variant for landscape that positions zoom slider vertically on right side
- document landscape slider behavior in README and AppFeatures
- mark feature task in TASK.md
- test layout file orientation via a new unit test

## Testing
- `./gradlew testDebugUnitTest` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_686dde6ccb748328833e583fd75320b5