### PR TITLE
Add landscape capture layout

### DIFF
--- a/AppFeatures.txt
+++ b/AppFeatures.txt
@@ -13,6 +13,7 @@ The project is a minimal Android application written in Kotlin. Below are all of
 * Includes a **Capture** button. When tapped it captures a photo to a temporary file, rotates the image based on the current setting and runs **ML Kit Text Recognition**.
 * Shows a green **TOP** label with a bounding box overlay so users align text correctly. The captured image is cropped to this region before processing.
 * Supports pinch-to-zoom on the preview with a slider and 1x reset button for precise adjustments.
+* In landscape orientation the **Capture** button is vertical on the right edge and the zoom controls center between the bounding box and the screen bottom.
 * The recognised text is displayed to the user in a simple alert dialog. Errors are printed to logcat.
 * Limitations:
   * Error handling is basic and does not present failures to the user beyond printing stack traces.

--- a/app/src/main/java/com/example/app/BoundingBoxOverlay.kt
+++ b/app/src/main/java/com/example/app/BoundingBoxOverlay.kt
@@ -42,6 +42,9 @@ class BoundingBoxOverlay @JvmOverloads constructor(
 
     override fun onDraw(canvas: Canvas) {
         super.onDraw(canvas)
+        // Reason: avoid drawing outside the view bounds which triggered
+        // "out of bounds transparent region" messages in logcat
+        canvas.clipRect(0f, 0f, width.toFloat(), height.toFloat())
         canvas.drawRect(rect, boxPaint)
         canvas.drawText("TOP", rect.centerX(), rect.top - 10f, textPaint)
     }

--- a/app/src/main/res/layout-land/activity_bin_locator.xml
+++ b/app/src/main/res/layout-land/activity_bin_locator.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <FrameLayout
+        android:id="@+id/previewContainer"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent">
+
+        <androidx.camera.view.PreviewView
+            android:id="@+id/viewFinder"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent" />
+
+        <com.example.app.BoundingBoxOverlay
+            android:id="@+id/boundingBox"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent" />
+    </FrameLayout>
+
+    <ImageButton
+        android:id="@+id/rotateButton"
+        android:layout_width="48dp"
+        android:layout_height="48dp"
+        android:layout_margin="8dp"
+        android:background="?attr/selectableItemBackgroundBorderless"
+        android:src="@drawable/ic_rotate"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintEnd_toStartOf="@id/captureButton" />
+
+    <Button
+        android:id="@+id/captureButton"
+        android:layout_width="48dp"
+        android:layout_height="wrap_content"
+        android:text="C\na\np\nt\nu\nr\ne"
+        android:gravity="center"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        android:layout_marginEnd="16dp" />
+
+    <Button
+        android:id="@+id/zoomResetButton"
+        android:layout_width="48dp"
+        android:layout_height="wrap_content"
+        android:text="1x"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/boundingBox"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintVertical_bias="0.5"
+        android:layout_marginStart="16dp" />
+
+    <com.google.android.material.slider.Slider
+        android:id="@+id/zoomSlider"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:valueFrom="0"
+        android:valueTo="1"
+        app:layout_constraintStart_toEndOf="@id/zoomResetButton"
+        app:layout_constraintEnd_toStartOf="@id/captureButton"
+        app:layout_constraintTop_toBottomOf="@id/boundingBox"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintVertical_bias="0.5"
+        android:layout_marginEnd="16dp" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
## Summary
- show Capture button vertically on the right in landscape
- center zoom controls below the bounding box in landscape
- document the updated UI behaviour

## Testing
- `./gradlew lint testDebugUnitTest` *(failed: process interrupted, packages installing)*

------
https://chatgpt.com/codex/tasks/task_e_686df3c1c7508328bbb73f4821ffb177