### PR TITLE
Fix landscape layout lint errors

### DIFF
--- a/app/src/main/res/layout-land/activity_bin_locator.xml
+++ b/app/src/main/res/layout-land/activity_bin_locator.xml
@@ -51,7 +51,7 @@
         android:layout_height="wrap_content"
         android:text="1x"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/boundingBox"
+        app:layout_constraintTop_toBottomOf="@id/previewContainer"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintVertical_bias="0.5"
         android:layout_marginStart="16dp" />
@@ -64,7 +64,7 @@
         android:valueTo="1"
         app:layout_constraintStart_toEndOf="@id/zoomResetButton"
         app:layout_constraintEnd_toStartOf="@id/captureButton"
-        app:layout_constraintTop_toBottomOf="@id/boundingBox"
+        app:layout_constraintTop_toBottomOf="@id/previewContainer"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintVertical_bias="0.5"
         android:layout_marginEnd="16dp" />


### PR DESCRIPTION
## Summary
- update `activity_bin_locator.xml` in `layout-land` to reference the preview container instead of the bounding box

## Testing
- `./gradlew lint`

------
https://chatgpt.com/codex/tasks/task_e_686ebb8b23bc8328a9580c58bcafd8af