### PR TITLE
Add action buttons container

### DIFF
--- a/app/src/androidTest/java/com/example/app/BarcodeUiTest.kt
+++ b/app/src/androidTest/java/com/example/app/BarcodeUiTest.kt
@@ -1,0 +1,26 @@
+package com.example.app
+
+import androidx.test.core.app.ActivityScenario
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
+import androidx.test.espresso.matcher.ViewMatchers.withId
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class BarcodeUiTest {
+    @Test
+    fun showResult_showsActionButtons() {
+        val scenario = ActivityScenario.launch(BinLocatorActivity::class.java)
+        scenario.onActivity { activity ->
+            val method = BinLocatorActivity::class.java.getDeclaredMethod("showResult", String::class.java)
+            method.isAccessible = true
+            method.invoke(activity, "test")
+        }
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync()
+        onView(withId(R.id.actionButtons)).check(matches(isDisplayed()))
+    }
+}

--- a/app/src/main/java/com/example/app/BinLocatorActivity.kt
+++ b/app/src/main/java/com/example/app/BinLocatorActivity.kt
@@ -8,6 +8,8 @@ import android.graphics.Bitmap
 import android.os.Bundle
 import android.widget.Button
 import android.widget.ImageButton
+import android.widget.LinearLayout
+import android.view.View
 import com.google.android.material.slider.Slider
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
@@ -36,6 +38,7 @@ class BinLocatorActivity : AppCompatActivity() {
     private lateinit var rotateButton: ImageButton
     private lateinit var zoomSlider: Slider
     private lateinit var zoomResetButton: Button
+    private lateinit var actionButtons: LinearLayout
     private lateinit var cameraExecutor: ExecutorService
     private lateinit var controller: LifecycleCameraController
     private var cameraProvider: ProcessCameraProvider? = null
@@ -52,6 +55,7 @@ class BinLocatorActivity : AppCompatActivity() {
         rotateButton = findViewById(R.id.rotateButton)
         zoomSlider = findViewById(R.id.zoomSlider)
         zoomResetButton = findViewById(R.id.zoomResetButton)
+        actionButtons = findViewById(R.id.actionButtons)
         cameraExecutor = Executors.newSingleThreadExecutor()
 
         rotateButton.setOnClickListener { toggleOrientation() }
@@ -125,6 +129,7 @@ class BinLocatorActivity : AppCompatActivity() {
 
     private fun showResult(text: String) {
         runOnUiThread {
+            actionButtons.visibility = View.VISIBLE
             AlertDialog.Builder(this)
                 .setMessage(text)
                 .setPositiveButton(android.R.string.ok, null)

--- a/app/src/main/res/layout-land/activity_bin_locator.xml
+++ b/app/src/main/res/layout-land/activity_bin_locator.xml
@@ -51,7 +51,7 @@
         android:layout_height="wrap_content"
         android:text="1x"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/boundingBox"
+        app:layout_constraintTop_toBottomOf="@id/previewContainer"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintVertical_bias="0.5"
         android:layout_marginStart="16dp" />
@@ -64,9 +64,21 @@
         android:valueTo="1"
         app:layout_constraintStart_toEndOf="@id/zoomResetButton"
         app:layout_constraintEnd_toStartOf="@id/captureButton"
-        app:layout_constraintTop_toBottomOf="@id/boundingBox"
+        app:layout_constraintTop_toBottomOf="@id/previewContainer"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintVertical_bias="0.5"
         android:layout_marginEnd="16dp" />
+
+    <LinearLayout
+        android:id="@+id/actionButtons"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:visibility="gone"
+        app:layout_constraintStart_toEndOf="@id/zoomSlider"
+        app:layout_constraintEnd_toStartOf="@id/captureButton"
+        app:layout_constraintTop_toBottomOf="@id/previewContainer"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintVertical_bias="0.5" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/activity_bin_locator.xml
+++ b/app/src/main/res/layout/activity_bin_locator.xml
@@ -66,4 +66,14 @@
         android:layout_marginEnd="16dp"
         android:layout_marginBottom="8dp" />
 
+    <LinearLayout
+        android:id="@+id/actionButtons"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:visibility="gone"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintBottom_toTopOf="@id/captureButton" />
+
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
## Summary
- add actionButtons container in BinLocator layout
- make BarcodeUiTest check for container visibility
- expose actionButtons in BinLocatorActivity and show it when OCR text is displayed

## Testing
- `./gradlew lint`
- `./gradlew testDebugUnitTest`
- `./gradlew connectedDebugAndroidTest` *(fails: No connected devices)*

------
https://chatgpt.com/codex/tasks/task_e_686ebb8c71988328891df1add14f0d93