### PR TITLE
Improve barcode scan logging

### DIFF
--- a/TASK.md
+++ b/TASK.md
@@ -2,3 +2,4 @@
 
 ## [2025-07-10] Generate PRP for OCR parsing feature - DONE
 ## [2025-07-10] Implement OCR parser utility
+## [2025-07-10] Add detailed logging for barcode scanning buttons


### PR DESCRIPTION
## Summary
- add debug log with crop coordinates
- log barcode details when scanning for release or bin values
- track task completion in TASK.md

## Testing
- `./gradlew lint`
- `./gradlew testDebugUnitTest`


------
https://chatgpt.com/codex/tasks/task_e_687006393c108328b36a84e271649ed8