### PR TITLE
Fix barcode scan logic

### DIFF
--- a/AppFeatures.txt
+++ b/AppFeatures.txt
@@ -18,7 +18,7 @@ The project is a minimal Android application written in Kotlin. Below are all of
 * Each OCR line and its bounding box height are printed to logcat for debugging.
 * OCR results are cleaned using `OcrParser` before barcode scanning.
 * Only the extracted roll number and customer name are displayed back to the user, simplifying the on-screen text.
-* **Get Release** and **Set Bin** buttons use ML Kit barcode scanning to extract a 7-digit release number or a `BIN:<#> UNTIED EXPRESS` value.
+* **Get Release** and **Set Bin** buttons use ML Kit barcode scanning. The raw value of the first detected code is displayed without additional parsing.
 * Errors are shown via Snackbars instead of only logcat output.
 * Limitations:
   * Error handling is basic and does not present failures to the user beyond printing stack traces.

--- a/README.md
+++ b/README.md
@@ -82,7 +82,8 @@ This app relies on Material Components. A custom theme extending `Theme.Material
   finer control when capturing text.
 - A rotate button switches the app between portrait and landscape modes, ensuring captured images match the screen orientation.
 - Recognised text is shown in a TextView with **Get Release** and **Set Bin**
-  buttons that scan barcodes using ML Kit.
+  buttons that scan barcodes using ML Kit. The raw value of the first detected
+  code is shown directly without regex filtering.
 - Each OCR line's bounding box height is printed to logcat alongside the text.
 - OCR results are cleaned with `OcrParser` before barcode scanning.
 - The parser now outputs only a roll number and customer name, displayed on two

--- a/TASK.md
+++ b/TASK.md
@@ -5,4 +5,5 @@
 ## [2025-07-10] Implement roll and customer extraction - DONE
 ## [2025-07-10] Generate PRP for roll and customer extraction - DONE
 ## [2025-07-10] Add detailed logging for barcode scanning buttons
+## [2025-07-10] Return raw barcode value without regex filtering - DONE
 

--- a/app/src/main/java/com/example/app/BarcodeUtils.kt
+++ b/app/src/main/java/com/example/app/BarcodeUtils.kt
@@ -2,24 +2,17 @@ package com.example.app
 
 import com.google.mlkit.vision.barcode.common.Barcode
 
-/** Utility functions for extracting release numbers and bin codes from barcodes. */
+/** Utility functions for returning raw barcode values. */
 object BarcodeUtils {
-    private val releaseRegex = Regex("\\b\\d{7}\\b")
-    private val binRegex = Regex("BIN:(\\d+) UNITED EXPRESS")
-
     /**
-     * Returns the first 7-digit release number from the barcode list.
+     * Returns the raw value of the first barcode, or `null` if none exist.
      */
     fun extractRelease(list: List<Barcode>): String? =
-        list.mapNotNull { it.rawValue }
-            .firstOrNull { releaseRegex.containsMatchIn(it) }
-            ?.let { releaseRegex.find(it)?.value }
+        list.firstOrNull()?.rawValue
 
     /**
-     * Returns the bin code from a QR pattern `BIN:<#> UNITED EXPRESS`.
+     * Returns the raw value of the first barcode, or `null` if none exist.
      */
     fun extractBin(list: List<Barcode>): String? =
-        list.mapNotNull { it.rawValue }
-            .firstOrNull { binRegex.containsMatchIn(it) }
-            ?.let { binRegex.find(it)?.groupValues?.get(1) }
+        list.firstOrNull()?.rawValue
 }

--- a/app/src/test/java/com/example/app/BarcodeUtilTest.kt
+++ b/app/src/test/java/com/example/app/BarcodeUtilTest.kt
@@ -14,20 +14,19 @@ class BarcodeUtilTest {
     }
 
     @Test
-    fun extractRelease_findsSevenDigits() {
-        val codes = listOf(fakeBarcode("foo"), fakeBarcode("1234567"))
-        assertEquals("1234567", BarcodeUtils.extractRelease(codes))
+    fun extractRelease_returnsFirstRawValue() {
+        val codes = listOf(fakeBarcode("abc"), fakeBarcode("def"))
+        assertEquals("abc", BarcodeUtils.extractRelease(codes))
     }
 
     @Test
-    fun extractRelease_returnsNullWhenMissing() {
-        val codes = listOf(fakeBarcode("foo"))
-        assertNull(BarcodeUtils.extractRelease(codes))
+    fun extractRelease_returnsNullWhenEmpty() {
+        assertNull(BarcodeUtils.extractRelease(emptyList()))
     }
 
     @Test
-    fun extractBin_parsesBinPattern() {
-        val codes = listOf(fakeBarcode("BIN:42 UNTIED EXPRESS"))
-        assertEquals("42", BarcodeUtils.extractBin(codes))
+    fun extractBin_returnsFirstRawValue() {
+        val codes = listOf(fakeBarcode("BIN:42"))
+        assertEquals("BIN:42", BarcodeUtils.extractBin(codes))
     }
 }


### PR DESCRIPTION
## Summary
- simplify `BarcodeUtils` to return the first raw code value
- adjust barcode utility unit tests
- describe the new behaviour in README and AppFeatures
- mark task complete in TASK.md

## Testing
- `./gradlew lint` *(fails: SDK location not found)*
- `./gradlew testDebugUnitTest` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6870189cc1708328af96fad579285a98