### PR TITLE
Add bin picker popup

### DIFF
--- a/AppFeatures.txt
+++ b/AppFeatures.txt
@@ -19,7 +19,9 @@ The project is a minimal Android application written in Kotlin. Below are all of
 * OCR results are cleaned using `OcrParser` before barcode scanning.
 * Only the extracted roll number and customer name are displayed back to the user, simplifying the on-screen text.
 * The parser strips any prefix text before the first space in the roll number so only the numeric portion remains.
-* **Get Release** and **Set Bin** buttons use ML Kit barcode scanning. The raw value of the first detected code is displayed without additional parsing.
+* **Get Release** still uses ML Kit barcode scanning. **Set Bin** now opens a menu
+  with bins 19-65 and "Floor BR/BL". Selected bins append `BIN=<value>` to the
+  roll number line.
 * Errors are shown via Snackbars instead of only logcat output.
 * Limitations:
   * Error handling is basic and does not present failures to the user beyond printing stack traces.

--- a/AppFeatures.txt
+++ b/AppFeatures.txt
@@ -20,8 +20,8 @@ The project is a minimal Android application written in Kotlin. Below are all of
 * Only the extracted roll number and customer name are displayed back to the user, simplifying the on-screen text.
 * The parser strips any prefix text before the first space in the roll number so only the numeric portion remains.
 * **Get Release** still uses ML Kit barcode scanning. **Set Bin** now opens a menu
-  with bins 19-65 and "Floor BR/BL". Selected bins append `BIN=<value>` to the
-  roll number line.
+  with bins 19-65 and "Floor BR/BL". Selected bins set `BIN=<value>` on the
+  roll number line, replacing any previous value.
 * Errors are shown via Snackbars instead of only logcat output.
 * Limitations:
   * Error handling is basic and does not present failures to the user beyond printing stack traces.

--- a/README.md
+++ b/README.md
@@ -83,8 +83,9 @@ This app relies on Material Components. A custom theme extending `Theme.Material
 - A rotate button switches the app between portrait and landscape modes, ensuring captured images match the screen orientation.
  - Recognised text is shown in a TextView with a **Get Release** button that
    scans barcodes using ML Kit. The **Set Bin** button now opens a pop-up menu
-   listing bins 19-65 plus "Floor BR" and "Floor BL". Selecting a value appends
-   `BIN=<bin>` to the roll number line. Barcode scanning for bins is disabled.
+  listing bins 19-65 plus "Floor BR" and "Floor BL". Selecting a value sets
+  `BIN=<bin>` on the roll number line, replacing any previous value. Barcode
+  scanning for bins is disabled.
 - Each OCR line's bounding box height is printed to logcat alongside the text.
 - OCR results are cleaned with `OcrParser` before barcode scanning.
 - The parser now outputs only a roll number and customer name, displayed on two

--- a/README.md
+++ b/README.md
@@ -81,9 +81,10 @@ This app relies on Material Components. A custom theme extending `Theme.Material
 - Camera preview supports pinch-to-zoom with a slider and a 1x reset button for
   finer control when capturing text.
 - A rotate button switches the app between portrait and landscape modes, ensuring captured images match the screen orientation.
-- Recognised text is shown in a TextView with **Get Release** and **Set Bin**
-  buttons that scan barcodes using ML Kit. The raw value of the first detected
-  code is shown directly without regex filtering.
+ - Recognised text is shown in a TextView with a **Get Release** button that
+   scans barcodes using ML Kit. The **Set Bin** button now opens a pop-up menu
+   listing bins 19-65 plus "Floor BR" and "Floor BL". Selecting a value appends
+   `BIN=<bin>` to the roll number line. Barcode scanning for bins is disabled.
 - Each OCR line's bounding box height is printed to logcat alongside the text.
 - OCR results are cleaned with `OcrParser` before barcode scanning.
 - The parser now outputs only a roll number and customer name, displayed on two

--- a/TASK.md
+++ b/TASK.md
@@ -8,4 +8,5 @@
 ## [2025-07-10] Return raw barcode value without regex filtering - DONE
 ## [2025-07-10] Trim roll prefix after extraction - DONE
 ## [2025-07-10] Replace bin QR scanning with manual selection popup
+## [2025-07-11] Fix bin selection to replace existing value instead of appending
 

--- a/TASK.md
+++ b/TASK.md
@@ -7,4 +7,5 @@
 ## [2025-07-10] Add detailed logging for barcode scanning buttons
 ## [2025-07-10] Return raw barcode value without regex filtering - DONE
 ## [2025-07-10] Trim roll prefix after extraction - DONE
+## [2025-07-10] Replace bin QR scanning with manual selection popup
 

--- a/app/src/androidTest/java/com/example/app/BinSelectionUiTest.kt
+++ b/app/src/androidTest/java/com/example/app/BinSelectionUiTest.kt
@@ -25,6 +25,9 @@ class BinSelectionUiTest {
         onView(withId(R.id.setBinButton)).perform(click())
         onView(withText("19")).perform(click())
         InstrumentationRegistry.getInstrumentation().waitForIdleSync()
-        onView(withId(R.id.ocrTextView)).check(matches(withText("Roll#:123 BIN=19")))
+        onView(withId(R.id.setBinButton)).perform(click())
+        onView(withText("20")).perform(click())
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync()
+        onView(withId(R.id.ocrTextView)).check(matches(withText("Roll#:123 BIN=20")))
     }
 }

--- a/app/src/androidTest/java/com/example/app/BinSelectionUiTest.kt
+++ b/app/src/androidTest/java/com/example/app/BinSelectionUiTest.kt
@@ -1,0 +1,30 @@
+package com.example.app
+
+import androidx.test.core.app.ActivityScenario
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.action.ViewActions.click
+import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.matcher.ViewMatchers.withId
+import androidx.test.espresso.matcher.ViewMatchers.withText
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class BinSelectionUiTest {
+    @Test
+    fun selectBin_updatesTextView() {
+        val scenario = ActivityScenario.launch(BinLocatorActivity::class.java)
+        scenario.onActivity { activity ->
+            val method = BinLocatorActivity::class.java.getDeclaredMethod("showResult", List::class.java)
+            method.isAccessible = true
+            method.invoke(activity, listOf("Roll#:123"))
+        }
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync()
+        onView(withId(R.id.setBinButton)).perform(click())
+        onView(withText("19")).perform(click())
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync()
+        onView(withId(R.id.ocrTextView)).check(matches(withText("Roll#:123 BIN=19")))
+    }
+}

--- a/app/src/main/java/com/example/app/BinLocatorActivity.kt
+++ b/app/src/main/java/com/example/app/BinLocatorActivity.kt
@@ -210,12 +210,21 @@ class BinLocatorActivity : AppCompatActivity() {
     private fun applyBin(bin: String) {
         runOnUiThread {
             val lines = ocrTextView.text.split("\n").toMutableList()
-            val index = lines.indexOfFirst { it.startsWith("Roll#:") }
-            if (index >= 0) {
-                lines[index] = lines[index] + " BIN=$bin"
+            val rollIndex = lines.indexOfFirst { it.startsWith("Roll#:") }
+
+            if (rollIndex >= 0) {
+                val withoutBin = lines[rollIndex].replace(Regex("\\s+BIN=.*"), "")
+                lines[rollIndex] = "$withoutBin BIN=$bin"
+                lines.removeAll { it.trim().startsWith("BIN=") && lines.indexOf(it) != rollIndex }
             } else {
-                lines.add("BIN=$bin")
+                val existing = lines.indexOfFirst { it.trim().startsWith("BIN=") }
+                if (existing >= 0) {
+                    lines[existing] = "BIN=$bin"
+                } else {
+                    lines.add("BIN=$bin")
+                }
             }
+
             ocrTextView.text = lines.joinToString("\n")
             Snackbar.make(previewView, "Bin: $bin", Snackbar.LENGTH_SHORT).show()
         }


### PR DESCRIPTION
## Summary
- replace Bin button barcode scanning with drop-down menu
- implement bin selection in `BinLocatorActivity`
- add instrumentation test for selecting a bin
- update feature docs and README with new behaviour
- note new task in TASK.md

## Testing
- `python scripts/decode_gradle_wrapper.py`
- `git lfs pull` *(failed: missing protocol)*
- `./scripts/install_android_sdk.sh` *(failed: interactive license prompt)*
- `./gradlew lint testDebugUnitTest` *(failed: network issues)*

------
https://chatgpt.com/codex/tasks/task_e_68704f313b648328866149dafcf257f9