### PR TITLE
Fix roll parsing and rename customer label

### DIFF
--- a/app/src/androidTest/java/com/example/app/SendRecordUiTest.kt
+++ b/app/src/androidTest/java/com/example/app/SendRecordUiTest.kt
@@ -19,7 +19,7 @@ class SendRecordUiTest {
         scenario.onActivity { activity ->
             val method = BinLocatorActivity::class.java.getDeclaredMethod("showResult", List::class.java)
             method.isAccessible = true
-            method.invoke(activity, listOf("Roll#:1", "Cust-Name:ACME", "BIN=19"))
+            method.invoke(activity, listOf("Roll#:1", "Cust:ACME", "BIN=19"))
         }
         InstrumentationRegistry.getInstrumentation().waitForIdleSync()
         onView(withId(R.id.sendRecordButton)).check(matches(isDisplayed()))

--- a/app/src/main/java/com/example/app/BinLocatorActivity.kt
+++ b/app/src/main/java/com/example/app/BinLocatorActivity.kt
@@ -239,15 +239,16 @@ class BinLocatorActivity : AppCompatActivity() {
     private fun updateSendRecordVisibility() {
         val textLines = ocrTextView.text.split("\n")
         val hasRoll = textLines.any { it.startsWith("Roll#:") }
-        val hasCust = textLines.any { it.startsWith("Cust-Name:") }
+        val hasCust = textLines.any { it.startsWith("Cust:") }
         val hasBin = textLines.any { it.contains("BIN=") }
         sendRecordButton.visibility = if (hasRoll && hasCust && hasBin) View.VISIBLE else View.GONE
     }
 
     private fun sendRecord() {
         val lines = ocrTextView.text.split("\n")
-        val roll = lines.firstOrNull { it.startsWith("Roll#:") }?.substringAfter("Roll#:")?.trim()
-        val customer = lines.firstOrNull { it.startsWith("Cust-Name:") }?.substringAfter("Cust-Name:")?.trim()
+        val rollLine = lines.firstOrNull { it.startsWith("Roll#:") }?.substringAfter("Roll#:")?.trim()
+        val roll = rollLine?.replace(Regex("\\s*BIN=.*"), "")?.trim()
+        val customer = lines.firstOrNull { it.startsWith("Cust:") }?.substringAfter("Cust:")?.trim()
         val bin = lines.firstOrNull { it.contains("BIN=") }?.substringAfter("BIN=")?.trim()
         if (roll == null || customer == null || bin == null) return
         RecordUploader.sendRecord(roll, customer, bin) { success ->

--- a/app/src/main/java/com/example/app/OcrParser.kt
+++ b/app/src/main/java/com/example/app/OcrParser.kt
@@ -50,6 +50,6 @@ object OcrParser {
 
         val rollStr = roll?.substringAfter(' ', roll) ?: ""
         val nameStr = name ?: ""
-        return listOf("Roll#:$rollStr", "Cust-Name:$nameStr")
+        return listOf("Roll#:$rollStr", "Cust:$nameStr")
     }
 }

--- a/app/src/test/java/com/example/app/OcrParserTest.kt
+++ b/app/src/test/java/com/example/app/OcrParserTest.kt
@@ -54,7 +54,7 @@ class OcrParserTest {
         )
         val result = OcrParser.parse(lines)
         assertEquals(
-            listOf("Roll#:ROLL 42", "Cust-Name:CUSTOMER ACME"),
+            listOf("Roll#:ROLL 42", "Cust:CUSTOMER ACME"),
             result
         )
     }
@@ -69,7 +69,7 @@ class OcrParserTest {
         )
         val result = OcrParser.parse(lines)
         assertEquals(
-            listOf("Roll#:98765", "Cust-Name:LONGESTNAME"),
+            listOf("Roll#:98765", "Cust:LONGESTNAME"),
             result
         )
     }
@@ -83,7 +83,7 @@ class OcrParserTest {
         )
         val result = OcrParser.parse(lines)
         assertEquals(
-            listOf("Roll#:12345", "Cust-Name:CUSTOMER ACME"),
+            listOf("Roll#:12345", "Cust:CUSTOMER ACME"),
             result
         )
     }


### PR DESCRIPTION
## Summary
- avoid including bin value when uploading roll number
- rename `Cust-Name:` lines to `Cust:` throughout the app and tests

## Testing
- `./gradlew testDebugUnitTest` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68709b8c867c8328b14652ea8f716c61