### PR TITLE
Add PIN entry feature

### DIFF
--- a/AppFeatures.txt
+++ b/AppFeatures.txt
@@ -3,7 +3,9 @@
 The project is a minimal Android application written in Kotlin. Below are all of the current features and how they operate.
 
 ## 1. Main Activity
-* Displays a "Hello World" text view on launch.
+* Requires entering a 4 digit PIN fetched from a Google Sheet before the main
+  screen appears.
+* Displays a "Hello World" text view on launch after successful PIN entry.
 * Contains a **Bin Locator** button. When pressed, this launches the `BinLocatorActivity` using an explicit intent.
 * Limitations: the main screen only provides navigation to the bin locator and does not contain additional functionality.
 

--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ This app relies on Material Components. A custom theme extending `Theme.Material
 
 ## Features
 
+ - Requires a 4 digit PIN on launch. Accepted PINs are fetched from a
+   Google Sheet so only authorized users can proceed.
  - Camera-based **Bin Locator** with a bounding box overlay guiding where to place
   text for OCR. The box now covers about **85%** of the screen for easier framing.
 - Captured images are cropped to this box and processed with ML Kit text

--- a/TASK.md
+++ b/TASK.md
@@ -12,4 +12,5 @@
 ## [2025-07-11] Generate PRP for Send Record feature - DONE
 ## [2025-07-11] Implement Send Record feature - DONE
 ## [2025-07-11] Display server error message on send failure - DONE
+## [2025-07-12] Add PIN entry screen before MainActivity - DONE
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -9,8 +9,9 @@
         android:label="BasicAndroidApp"
         android:theme="@style/Theme.BasicAndroidApp">
         <activity android:name=".BinLocatorActivity" />
+        <activity android:name=".MainActivity" />
         <activity
-            android:name=".MainActivity"
+            android:name=".PinEntryActivity"
             android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/app/src/main/java/com/example/app/PinEntryActivity.kt
+++ b/app/src/main/java/com/example/app/PinEntryActivity.kt
@@ -1,0 +1,44 @@
+package com.example.app
+
+import android.content.Intent
+import android.os.Bundle
+import android.widget.Button
+import android.widget.EditText
+import androidx.appcompat.app.AppCompatActivity
+import com.google.android.material.snackbar.Snackbar
+
+class PinEntryActivity : AppCompatActivity() {
+    private lateinit var pinEditText: EditText
+    private lateinit var submitButton: Button
+    private var pins: List<String> = emptyList()
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_pin_entry)
+        pinEditText = findViewById(R.id.pinEditText)
+        submitButton = findViewById(R.id.submitPinButton)
+
+        submitButton.setOnClickListener { validatePin() }
+        loadPins()
+    }
+
+    private fun loadPins() {
+        PinFetcher.fetchPins { list ->
+            pins = list
+        }
+    }
+
+    private fun validatePin() {
+        val input = pinEditText.text.toString().trim()
+        if (input.length != 4) {
+            Snackbar.make(pinEditText, "Enter 4 digit PIN", Snackbar.LENGTH_SHORT).show()
+            return
+        }
+        if (pins.contains(input)) {
+            startActivity(Intent(this, MainActivity::class.java))
+            finish()
+        } else {
+            Snackbar.make(pinEditText, "Invalid PIN", Snackbar.LENGTH_SHORT).show()
+        }
+    }
+}

--- a/app/src/main/java/com/example/app/PinFetcher.kt
+++ b/app/src/main/java/com/example/app/PinFetcher.kt
@@ -1,0 +1,36 @@
+package com.example.app
+
+import java.net.HttpURLConnection
+import java.net.URL
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors
+
+object PinFetcher {
+    private val executor: ExecutorService = Executors.newSingleThreadExecutor()
+    var connectionFactory: (URL) -> HttpURLConnection = { url ->
+        url.openConnection() as HttpURLConnection
+    }
+    private const val CSV_URL = "https://docs.google.com/spreadsheets/d/1Xok6zJcUC_bizTy303VFCZHkrFBtW1IxeuT4PIw7Ngo/export?format=csv"
+
+    fun fetchPins(onComplete: (List<String>) -> Unit) {
+        executor.execute {
+            try {
+                val url = URL(CSV_URL)
+                val conn = connectionFactory(url)
+                val csv = conn.inputStream.bufferedReader().use { it.readText() }
+                conn.disconnect()
+                onComplete(parsePins(csv))
+            } catch (e: Exception) {
+                onComplete(emptyList())
+            }
+        }
+    }
+
+    internal fun parsePins(csv: String): List<String> {
+        return csv.lines()
+            .drop(1)
+            .mapNotNull { line ->
+                line.split(',').firstOrNull()?.trim()?.takeIf { it.isNotEmpty() }
+            }
+    }
+}

--- a/app/src/main/res/layout/activity_pin_entry.xml
+++ b/app/src/main/res/layout/activity_pin_entry.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <EditText
+        android:id="@+id/pinEditText"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:inputType="numberPassword"
+        android:maxLength="4"
+        android:hint="Enter PIN"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
+
+    <Button
+        android:id="@+id/submitPinButton"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Submit"
+        app:layout_constraintTop_toBottomOf="@id/pinEditText"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/test/java/com/example/app/PinFetcherTest.kt
+++ b/app/src/test/java/com/example/app/PinFetcherTest.kt
@@ -1,0 +1,46 @@
+package com.example.app
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import java.net.HttpURLConnection
+import java.net.URL
+
+@RunWith(RobolectricTestRunner::class)
+class PinFetcherTest {
+    @Test
+    fun parsePins_returnsFirstColumn() {
+        val csv = "Pins,Name\n1234,Bob\n4567,Alice"
+        val result = PinFetcher.parsePins(csv)
+        assertEquals(listOf("1234", "4567"), result)
+    }
+
+    @Test
+    fun fetchPins_returnsParsedPins() {
+        val csv = "Pins,Name\n1111,Bob"
+        val conn = object : HttpURLConnection(URL("http://test")) {
+            override fun getInputStream() = csv.byteInputStream()
+            override fun getResponseCode() = 200
+            override fun connect() {}
+            override fun disconnect() {}
+            override fun usingProxy() = false
+            override fun getOutputStream() = java.io.ByteArrayOutputStream()
+        }
+        PinFetcher.connectionFactory = { conn }
+        var result: List<String> = emptyList()
+        PinFetcher.fetchPins { list -> result = list }
+        Thread.sleep(100)
+        assertEquals(listOf("1111"), result)
+    }
+
+    @Test
+    fun fetchPins_handlesFailure() {
+        PinFetcher.connectionFactory = { throw RuntimeException("bad") }
+        var result: List<String> = listOf("x")
+        PinFetcher.fetchPins { list -> result = list }
+        Thread.sleep(100)
+        assertTrue(result.isEmpty())
+    }
+}


### PR DESCRIPTION
## Summary
- require a 4 digit PIN before the main screen
- fetch allowed PINs from a Google Sheet
- update manifest for new PinEntryActivity launcher
- document new login requirement in README and AppFeatures
- add unit tests for PinFetcher

## Testing
- `./gradlew testDebugUnitTest` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68716d55eb7c832889e2a804dc80a8d1