### PR TITLE
Add PIN entry feature

### DIFF
--- a/AppFeatures.txt
+++ b/AppFeatures.txt
@@ -3,9 +3,14 @@
 The project is a minimal Android application written in Kotlin. Below are all of the current features and how they operate.
 
 ## 1. Main Activity
-* Displays a "Hello World" text view on launch.
+* Displays a "Hello World" text view after a PIN check.
 * Contains a **Bin Locator** button. When pressed, this launches the `BinLocatorActivity` using an explicit intent.
 * Limitations: the main screen only provides navigation to the bin locator and does not contain additional functionality.
+
+## 1a. Pin Activity
+* Shown at app start to request a 4-digit PIN.
+* Accepted pins are downloaded from a Google Sheet.
+* On success the user is taken to the main menu. Invalid pins show a Snackbar error.
 
 ## 2. Bin Locator Activity
 * Provides a camera preview using **CameraX**. When the screen loads it requests the camera permission if needed and starts the camera.

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ This app relies on Material Components. A custom theme extending `Theme.Material
 
 ## Features
 
- - Camera-based **Bin Locator** with a bounding box overlay guiding where to place
+- Camera-based **Bin Locator** with a bounding box overlay guiding where to place
   text for OCR. The box now covers about **85%** of the screen for easier framing.
 - Captured images are cropped to this box and processed with ML Kit text
   recognition.
@@ -94,3 +94,5 @@ This app relies on Material Components. A custom theme extending `Theme.Material
 - Once roll, customer and bin are present a **Send Record** button appears.
   Tapping uploads the data to the server and clears the text view. If the server
   returns an error, the provided message is shown instead of a generic failure.
+- App opens with a 4-digit **PIN entry** screen. Valid pins are fetched from a
+  Google Sheet so only authorized users can continue to the main menu.

--- a/TASK.md
+++ b/TASK.md
@@ -12,4 +12,5 @@
 ## [2025-07-11] Generate PRP for Send Record feature - DONE
 ## [2025-07-11] Implement Send Record feature - DONE
 ## [2025-07-11] Display server error message on send failure - DONE
+## [2025-07-11] Prompt for 4-digit PIN on launch - DONE
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,7 @@
     package="com.example.app">
 
     <uses-permission android:name="android.permission.CAMERA" />
+    <uses-permission android:name="android.permission.INTERNET" />
     <!-- Allow install on devices without a camera such as Chromebooks -->
     <uses-feature android:name="android.hardware.camera" android:required="false" />
 
@@ -9,8 +10,9 @@
         android:label="BasicAndroidApp"
         android:theme="@style/Theme.BasicAndroidApp">
         <activity android:name=".BinLocatorActivity" />
+        <activity android:name=".MainActivity" />
         <activity
-            android:name=".MainActivity"
+            android:name=".PinActivity"
             android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/app/src/main/java/com/example/app/PinActivity.kt
+++ b/app/src/main/java/com/example/app/PinActivity.kt
@@ -1,0 +1,54 @@
+package com.example.app
+
+import android.content.Intent
+import android.os.Bundle
+import android.view.View
+import android.widget.Button
+import android.widget.EditText
+import android.widget.ProgressBar
+import androidx.appcompat.app.AppCompatActivity
+import com.google.android.material.snackbar.Snackbar
+
+class PinActivity : AppCompatActivity() {
+    private lateinit var pinEdit: EditText
+    private lateinit var submitButton: Button
+    private lateinit var progress: ProgressBar
+    private var validPins: Set<String> = emptySet()
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_pin)
+
+        pinEdit = findViewById(R.id.pinEdit)
+        submitButton = findViewById(R.id.pinSubmit)
+        progress = findViewById(R.id.pinProgress)
+
+        submitButton.setOnClickListener {
+            val entered = pinEdit.text.toString()
+            if (entered in validPins) {
+                startActivity(Intent(this, MainActivity::class.java))
+                finish()
+            } else {
+                Snackbar.make(pinEdit, "Invalid PIN", Snackbar.LENGTH_SHORT).show()
+            }
+        }
+
+        fetchPins()
+    }
+
+    private fun fetchPins() {
+        progress.visibility = View.VISIBLE
+        submitButton.isEnabled = false
+        PinRepository.fetchPins { pins, error ->
+            runOnUiThread {
+                progress.visibility = View.GONE
+                submitButton.isEnabled = true
+                if (error != null) {
+                    Snackbar.make(pinEdit, "Failed to load pins", Snackbar.LENGTH_LONG).show()
+                }
+                validPins = pins
+            }
+        }
+    }
+}
+

--- a/app/src/main/java/com/example/app/PinRepository.kt
+++ b/app/src/main/java/com/example/app/PinRepository.kt
@@ -1,0 +1,35 @@
+package com.example.app
+
+import java.io.BufferedReader
+import java.io.InputStreamReader
+import java.net.HttpURLConnection
+import java.net.URL
+
+object PinRepository {
+    private const val CSV_URL = "https://docs.google.com/spreadsheets/d/1Xok6zJcUC_bizTy303VFCZHkrFBtW1IxeuT4PIw7Ngo/export?format=csv"
+
+    fun fetchPins(callback: (Set<String>, Exception?) -> Unit) {
+        Thread {
+            try {
+                val url = URL(CSV_URL)
+                val conn = url.openConnection() as HttpURLConnection
+                conn.connectTimeout = 5000
+                conn.readTimeout = 5000
+                val csv = conn.inputStream.bufferedReader().use(BufferedReader::readText)
+                val pins = parsePins(csv)
+                callback(pins, null)
+            } catch (e: Exception) {
+                callback(emptySet(), e)
+            }
+        }.start()
+    }
+
+    fun parsePins(csv: String): Set<String> {
+        return csv.lineSequence()
+            .drop(1)
+            .map { line -> line.split(',').firstOrNull()?.trim() ?: "" }
+            .filter { it.isNotEmpty() }
+            .toSet()
+    }
+}
+

--- a/app/src/main/res/layout/activity_pin.xml
+++ b/app/src/main/res/layout/activity_pin.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:padding="16dp">
+
+    <EditText
+        android:id="@+id/pinEdit"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:inputType="numberPassword"
+        android:maxLength="4"
+        android:hint="Enter PIN" />
+
+    <ProgressBar
+        android:id="@+id/pinProgress"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:visibility="gone"
+        android:layout_gravity="center_horizontal" />
+
+    <Button
+        android:id="@+id/pinSubmit"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Continue"
+        android:layout_gravity="center_horizontal" />
+</LinearLayout>
+

--- a/app/src/test/java/com/example/app/PinRepositoryTest.kt
+++ b/app/src/test/java/com/example/app/PinRepositoryTest.kt
@@ -1,0 +1,21 @@
+package com.example.app
+
+import org.junit.Test
+import org.junit.Assert.assertEquals
+
+class PinRepositoryTest {
+    @Test
+    fun parsePins_extractsPins() {
+        val csv = "Pins,Assigned\n1111,A\n2222,B\n"
+        val expected = setOf("1111", "2222")
+        assertEquals(expected, PinRepository.parsePins(csv))
+    }
+
+    @Test
+    fun parsePins_ignoresEmptyLines() {
+        val csv = "Pins,Assigned\n\n3333,C\n"
+        val expected = setOf("3333")
+        assertEquals(expected, PinRepository.parsePins(csv))
+    }
+}
+


### PR DESCRIPTION
## Summary
- prompt for 4-digit PIN when the app launches
- load allowed PINs from a Google Sheet
- document new feature in README and AppFeatures
- record task completion
- add tests for PIN parsing

## Testing
- `./gradlew lint` *(fails: SDK location not found)*
- `./gradlew testDebugUnitTest` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68716d55eb7c832889e2a804dc80a8d1