### PR TITLE
Implement PIN prompt on launch

### DIFF
--- a/AppFeatures.txt
+++ b/AppFeatures.txt
@@ -4,6 +4,7 @@ The project is a minimal Android application written in Kotlin. Below are all of
 
 ## 1. Main Activity
 * Displays a "Hello World" text view on launch.
+* Loads a list of valid 4-digit PINs from a Google Sheet and prompts the user to enter one before enabling the Bin Locator.
 * Contains a **Bin Locator** button. When pressed, this launches the `BinLocatorActivity` using an explicit intent.
 * Limitations: the main screen only provides navigation to the bin locator and does not contain additional functionality.
 

--- a/README.md
+++ b/README.md
@@ -94,3 +94,6 @@ This app relies on Material Components. A custom theme extending `Theme.Material
 - Once roll, customer and bin are present a **Send Record** button appears.
   Tapping uploads the data to the server and clears the text view. If the server
   returns an error, the provided message is shown instead of a generic failure.
+- On startup the app fetches a list of valid 4-digit PINs from a Google Sheet
+  and prompts the user to enter one. The main screen remains disabled until a
+  correct PIN is provided.

--- a/TASK.md
+++ b/TASK.md
@@ -12,4 +12,5 @@
 ## [2025-07-11] Generate PRP for Send Record feature - DONE
 ## [2025-07-11] Implement Send Record feature - DONE
 ## [2025-07-11] Display server error message on send failure - DONE
+## [2025-07-11] Prompt for PIN on startup and fetch allowed list from Google Sheet - DONE
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,7 +1,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.example.app">
 
-    <uses-permission android:name="android.permission.CAMERA" />
+<uses-permission android:name="android.permission.CAMERA" />
+    <uses-permission android:name="android.permission.INTERNET" />
     <!-- Allow install on devices without a camera such as Chromebooks -->
     <uses-feature android:name="android.hardware.camera" android:required="false" />
 

--- a/app/src/main/java/com/example/app/MainActivity.kt
+++ b/app/src/main/java/com/example/app/MainActivity.kt
@@ -2,15 +2,53 @@ package com.example.app
 
 import android.content.Intent
 import android.os.Bundle
+import android.text.InputType
 import android.widget.Button
+import android.widget.EditText
+import android.widget.Toast
+import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
 
 class MainActivity : AppCompatActivity() {
+    private lateinit var binButton: Button
+    private var allowedPins: Set<String> = emptySet()
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
-        findViewById<Button>(R.id.binLocatorButton).setOnClickListener {
+        binButton = findViewById(R.id.binLocatorButton)
+        binButton.isEnabled = false
+        binButton.setOnClickListener {
             startActivity(Intent(this, BinLocatorActivity::class.java))
         }
+
+        PinFetcher.fetchPins({ pins ->
+            allowedPins = pins
+            runOnUiThread { showPinDialog() }
+        }, { e ->
+            runOnUiThread {
+                Toast.makeText(this, "Failed to load PINs", Toast.LENGTH_LONG).show()
+                finish()
+            }
+        })
+    }
+
+    private fun showPinDialog() {
+        val input = EditText(this).apply { inputType = InputType.TYPE_CLASS_NUMBER }
+        AlertDialog.Builder(this)
+            .setTitle("Enter PIN")
+            .setView(input)
+            .setCancelable(false)
+            .setPositiveButton("OK") { _, _ ->
+                val pin = input.text.toString().trim()
+                if (pin.length == 4 && allowedPins.contains(pin)) {
+                    binButton.isEnabled = true
+                } else {
+                    Toast.makeText(this, "Invalid PIN", Toast.LENGTH_SHORT).show()
+                    showPinDialog()
+                }
+            }
+            .setNegativeButton("Exit") { _, _ -> finish() }
+            .show()
     }
 }

--- a/app/src/main/java/com/example/app/PinFetcher.kt
+++ b/app/src/main/java/com/example/app/PinFetcher.kt
@@ -1,0 +1,45 @@
+package com.example.app
+
+import java.net.HttpURLConnection
+import java.net.URL
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors
+
+/** Utility for fetching and parsing allowed PINs from a Google Sheet. */
+object PinFetcher {
+    private val executor: ExecutorService = Executors.newSingleThreadExecutor()
+
+    private const val SHEET_URL =
+        "https://docs.google.com/spreadsheets/d/1Xok6zJcUC_bizTy303VFCZHkrFBtW1IxeuT4PIw7Ngo/export?format=csv&gid=0"
+
+    /** Parses the first column of the provided CSV text and returns unique PINs. */
+    fun parseCsv(csv: String): Set<String> {
+        return csv.lines()
+            .drop(1) // remove header
+            .mapNotNull { line -> line.split(',').firstOrNull()?.trim() }
+            .filter { it.isNotEmpty() }
+            .toSet()
+    }
+
+    /**
+     * Fetches the allowed PINs from the Google Sheet.
+     *
+     * @param onSuccess called with the fetched PIN set.
+     * @param onError called if the fetch fails.
+     */
+    fun fetchPins(onSuccess: (Set<String>) -> Unit, onError: (Exception) -> Unit) {
+        executor.execute {
+            try {
+                val url = URL(SHEET_URL)
+                val conn = url.openConnection() as HttpURLConnection
+                conn.connect()
+                val csv = conn.inputStream.bufferedReader().readText()
+                conn.disconnect()
+                val pins = parseCsv(csv)
+                onSuccess(pins)
+            } catch (e: Exception) {
+                onError(e)
+            }
+        }
+    }
+}

--- a/app/src/test/java/com/example/app/PinFetcherTest.kt
+++ b/app/src/test/java/com/example/app/PinFetcherTest.kt
@@ -1,0 +1,19 @@
+package com.example.app
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class PinFetcherTest {
+    @Test
+    fun parseCsv_returnsPins() {
+        val csv = "Pins,Assigned\n1234,Alice\n5678,Bob"
+        val expected = setOf("1234", "5678")
+        assertEquals(expected, PinFetcher.parseCsv(csv))
+    }
+
+    @Test
+    fun parseCsv_handlesEmpty() {
+        val csv = "Pins,Assigned\n"
+        assertEquals(emptySet<String>(), PinFetcher.parseCsv(csv))
+    }
+}


### PR DESCRIPTION
## Summary
- fetch PIN list from Google Sheets
- prompt for PIN before enabling Bin Locator screen
- require Internet permission
- document new security feature
- add unit tests for PIN parsing

## Testing
- `./gradlew lint` *(fails: SDK location not found)*
- `./gradlew testDebugUnitTest` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68716d55eb7c832889e2a804dc80a8d1