### PR TITLE
Refactor button layout for debug options

### DIFF
--- a/TASK.md
+++ b/TASK.md
@@ -22,3 +22,4 @@
 ## [2025-07-14] Implement Batch Binning mode - DONE
 ## [2025-07-14] Default to Batch mode and remove checkbox - DONE
 ## [2025-07-14] Remove rotate button and lock orientation to portrait - DONE
+## [2025-07-14] Refactor button layout and send button visibility

--- a/app/src/main/java/com/example/app/BinLocatorActivity.kt
+++ b/app/src/main/java/com/example/app/BinLocatorActivity.kt
@@ -93,10 +93,10 @@ class BinLocatorActivity : AppCompatActivity() {
             showBatchButton.visibility = View.VISIBLE
         }
         if (debugMode) {
-            sendRecordButton.visibility = View.GONE
             showOcrButton.visibility = View.VISIBLE
             showCropButton.visibility = View.VISIBLE
         }
+        sendRecordButton.isEnabled = false
 
         captureButton.setOnClickListener { takePhoto() }
         getReleaseButton.setOnClickListener { scanRelease() }
@@ -271,7 +271,7 @@ class BinLocatorActivity : AppCompatActivity() {
 
     private fun updateSendRecordVisibility() {
         if (debugMode) {
-            sendRecordButton.visibility = View.GONE
+            sendRecordButton.isEnabled = false
             return
         }
         val textLines = ocrTextView.text.split("\n")
@@ -279,7 +279,7 @@ class BinLocatorActivity : AppCompatActivity() {
         val hasCust = textLines.any { it.startsWith("Cust:") }
         val hasBin = textLines.any { it.contains("BIN=") }
         val batchReady = batchMode && batchItems.isNotEmpty() && batchItems.all { it.bin != null }
-        sendRecordButton.visibility = if ((hasRoll && hasCust && hasBin) || batchReady) View.VISIBLE else View.GONE
+        sendRecordButton.isEnabled = (hasRoll && hasCust && hasBin) || batchReady
     }
 
     private fun sendRecord() {
@@ -315,7 +315,7 @@ class BinLocatorActivity : AppCompatActivity() {
             batchItems.clear()
             ocrTextView.text = ""
             actionButtons.visibility = View.GONE
-            sendRecordButton.visibility = View.GONE
+            sendRecordButton.isEnabled = false
         }
     }
 

--- a/app/src/main/res/layout/activity_bin_locator.xml
+++ b/app/src/main/res/layout/activity_bin_locator.xml
@@ -38,38 +38,46 @@
             android:layout_height="wrap_content"
             android:layout_weight="1"
             android:text="Set Bin" />
+    </LinearLayout>
 
-        <Button
-            android:id="@+id/sendRecordButton"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_weight="1"
-            android:visibility="gone"
-            android:text="Send Record" />
+    <LinearLayout
+        android:id="@+id/showButtons"
+        android:layout_width="wrap_content"
+        android:layout_height="0dp"
+        android:orientation="vertical"
+        android:layout_margin="4dp"
+        app:layout_constraintTop_toBottomOf="@id/actionButtons"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@id/previewContainer">
 
         <Button
             android:id="@+id/showOcrButton"
-            android:layout_width="0dp"
+            android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_weight="1"
             android:visibility="gone"
             android:text="Show OCR" />
 
         <Button
             android:id="@+id/showCropButton"
-            android:layout_width="0dp"
+            android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_weight="1"
             android:visibility="gone"
             android:text="Show Crop" />
 
         <Button
             android:id="@+id/showBatchButton"
-            android:layout_width="0dp"
+            android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_weight="1"
             android:visibility="gone"
             android:text="Show Items" />
+
+        <Button
+            android:id="@+id/sendRecordButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Send Record"
+            android:enabled="false" />
     </LinearLayout>
 
     <FrameLayout
@@ -79,7 +87,7 @@
         app:layout_constraintTop_toBottomOf="@id/actionButtons"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent">
+        app:layout_constraintEnd_toStartOf="@id/showButtons">
 
         <androidx.camera.view.PreviewView
             android:id="@+id/viewFinder"
@@ -102,7 +110,7 @@
 
     <Button
         android:id="@+id/captureButton"
-        android:layout_width="wrap_content"
+        android:layout_width="120dp"
         android:layout_height="wrap_content"
         android:text="Capture"
         app:layout_constraintBottom_toBottomOf="parent"
@@ -119,7 +127,7 @@
         android:layout_marginBottom="16dp"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintStart_toEndOf="@id/captureButton"
-        app:layout_constraintEnd_toEndOf="parent" />
+        app:layout_constraintEnd_toStartOf="@id/showButtons" />
 
     <Button
         android:id="@+id/zoomResetButton"
@@ -138,7 +146,7 @@
         android:valueFrom="0"
         android:valueTo="1"
         app:layout_constraintStart_toEndOf="@id/zoomResetButton"
-        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintEnd_toStartOf="@id/showButtons"
         app:layout_constraintBottom_toTopOf="@id/captureButton"
         android:layout_marginEnd="16dp"
         android:layout_marginBottom="8dp" />

--- a/app/src/test/java/com/example/app/BinLocatorUnitTest.kt
+++ b/app/src/test/java/com/example/app/BinLocatorUnitTest.kt
@@ -29,6 +29,7 @@ class BinLocatorUnitTest {
         val controller = Robolectric.buildActivity(BinLocatorActivity::class.java, intent).setup()
         val activity = controller.get()
         val button = activity.findViewById<android.widget.Button>(R.id.sendRecordButton)
-        assertEquals(android.view.View.GONE, button.visibility)
+        assertEquals(android.view.View.VISIBLE, button.visibility)
+        assertEquals(false, button.isEnabled)
     }
 }


### PR DESCRIPTION
## Summary
- reorganize Bin Locator layout into two button containers
- move debug buttons and send record button to a vertical side panel
- keep send record button visible but disabled until requirements met
- enlarge capture button width
- update test expectation for debug mode
- note task in TASK.md

## Testing
- `./gradlew testDebugUnitTest` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6874b25c57348328b42ee1185cb84d55