### PR TITLE
UI container cleanup and disabled send button

### DIFF
--- a/TASK.md
+++ b/TASK.md
@@ -22,3 +22,4 @@
 ## [2025-07-14] Implement Batch Binning mode - DONE
 ## [2025-07-14] Default to Batch mode and remove checkbox - DONE
 ## [2025-07-14] Remove rotate button and lock orientation to portrait - DONE
+## [2025-07-14] Move debug buttons to side container and disable Send button until ready

--- a/app/src/androidTest/java/com/example/app/DebugUiTest.kt
+++ b/app/src/androidTest/java/com/example/app/DebugUiTest.kt
@@ -5,6 +5,7 @@ import androidx.test.core.app.ActivityScenario
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.matcher.ViewMatchers.*
+import org.hamcrest.Matchers.not
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -12,13 +13,14 @@ import org.junit.runner.RunWith
 @RunWith(AndroidJUnit4::class)
 class DebugUiTest {
     @Test
-    fun debugMode_showsButtonsAndHidesSend() {
+    fun debugMode_showsButtonsAndDisablesSend() {
         val intent = Intent( androidx.test.platform.app.InstrumentationRegistry.getInstrumentation().targetContext, BinLocatorActivity::class.java )
         intent.putExtra("debug", true)
         ActivityScenario.launch<BinLocatorActivity>(intent).use {
             onView(withId(R.id.showOcrButton)).check(matches(isDisplayed()))
             onView(withId(R.id.showCropButton)).check(matches(isDisplayed()))
-            onView(withId(R.id.sendRecordButton)).check(matches(withEffectiveVisibility(Visibility.GONE)))
+            onView(withId(R.id.sendRecordButton)).check(matches(isDisplayed()))
+            onView(withId(R.id.sendRecordButton)).check(matches(not(isEnabled())))
         }
     }
 }

--- a/app/src/androidTest/java/com/example/app/SendRecordUiTest.kt
+++ b/app/src/androidTest/java/com/example/app/SendRecordUiTest.kt
@@ -4,8 +4,7 @@ import androidx.test.core.app.ActivityScenario
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.assertion.ViewAssertions.matches
-import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
-import androidx.test.espresso.matcher.ViewMatchers.withId
+import androidx.test.espresso.matcher.ViewMatchers.*
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import org.junit.Test
@@ -14,7 +13,7 @@ import org.junit.runner.RunWith
 @RunWith(AndroidJUnit4::class)
 class SendRecordUiTest {
     @Test
-    fun showResult_displaysSendButton() {
+    fun showResult_enablesSendButton() {
         val scenario = ActivityScenario.launch(BinLocatorActivity::class.java)
         scenario.onActivity { activity ->
             val method = BinLocatorActivity::class.java.getDeclaredMethod("showResult", List::class.java)
@@ -22,6 +21,6 @@ class SendRecordUiTest {
             method.invoke(activity, listOf("Roll#:1", "Cust:ACME", "BIN=19"))
         }
         InstrumentationRegistry.getInstrumentation().waitForIdleSync()
-        onView(withId(R.id.sendRecordButton)).check(matches(isDisplayed()))
+        onView(withId(R.id.sendRecordButton)).check(matches(isEnabled()))
     }
 }

--- a/app/src/main/java/com/example/app/BinLocatorActivity.kt
+++ b/app/src/main/java/com/example/app/BinLocatorActivity.kt
@@ -93,10 +93,10 @@ class BinLocatorActivity : AppCompatActivity() {
             showBatchButton.visibility = View.VISIBLE
         }
         if (debugMode) {
-            sendRecordButton.visibility = View.GONE
             showOcrButton.visibility = View.VISIBLE
             showCropButton.visibility = View.VISIBLE
         }
+        sendRecordButton.isEnabled = false
 
         captureButton.setOnClickListener { takePhoto() }
         getReleaseButton.setOnClickListener { scanRelease() }
@@ -270,16 +270,14 @@ class BinLocatorActivity : AppCompatActivity() {
     }
 
     private fun updateSendRecordVisibility() {
-        if (debugMode) {
-            sendRecordButton.visibility = View.GONE
-            return
-        }
         val textLines = ocrTextView.text.split("\n")
         val hasRoll = textLines.any { it.startsWith("Roll#:") }
         val hasCust = textLines.any { it.startsWith("Cust:") }
         val hasBin = textLines.any { it.contains("BIN=") }
         val batchReady = batchMode && batchItems.isNotEmpty() && batchItems.all { it.bin != null }
-        sendRecordButton.visibility = if ((hasRoll && hasCust && hasBin) || batchReady) View.VISIBLE else View.GONE
+        val enabled = !debugMode && ((hasRoll && hasCust && hasBin) || batchReady)
+        sendRecordButton.isEnabled = enabled
+        sendRecordButton.alpha = if (enabled) 1f else 0.5f
     }
 
     private fun sendRecord() {
@@ -315,7 +313,8 @@ class BinLocatorActivity : AppCompatActivity() {
             batchItems.clear()
             ocrTextView.text = ""
             actionButtons.visibility = View.GONE
-            sendRecordButton.visibility = View.GONE
+            sendRecordButton.isEnabled = false
+            sendRecordButton.alpha = 0.5f
         }
     }
 

--- a/app/src/main/res/layout/activity_bin_locator.xml
+++ b/app/src/main/res/layout/activity_bin_locator.xml
@@ -22,7 +22,7 @@
         android:orientation="horizontal"
         android:visibility="gone"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintEnd_toStartOf="@+id/showButtonsContainer"
         app:layout_constraintTop_toBottomOf="@id/ocrTextView">
 
         <Button
@@ -39,37 +39,43 @@
             android:layout_weight="1"
             android:text="Set Bin" />
 
+    </LinearLayout>
+
+    <LinearLayout
+        android:id="@+id/showButtonsContainer"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        app:layout_constraintTop_toBottomOf="@id/actionButtons"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintBottom_toBottomOf="@id/previewContainer">
+
+        <Button
+            android:id="@+id/showBatchButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:visibility="gone"
+            android:text="Show Items" />
+
         <Button
             android:id="@+id/sendRecordButton"
-            android:layout_width="0dp"
+            android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_weight="1"
-            android:visibility="gone"
             android:text="Send Record" />
 
         <Button
             android:id="@+id/showOcrButton"
-            android:layout_width="0dp"
+            android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_weight="1"
             android:visibility="gone"
             android:text="Show OCR" />
 
         <Button
             android:id="@+id/showCropButton"
-            android:layout_width="0dp"
+            android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_weight="1"
             android:visibility="gone"
             android:text="Show Crop" />
-
-        <Button
-            android:id="@+id/showBatchButton"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_weight="1"
-            android:visibility="gone"
-            android:text="Show Items" />
     </LinearLayout>
 
     <FrameLayout
@@ -102,7 +108,7 @@
 
     <Button
         android:id="@+id/captureButton"
-        android:layout_width="wrap_content"
+        android:layout_width="120dp"
         android:layout_height="wrap_content"
         android:text="Capture"
         app:layout_constraintBottom_toBottomOf="parent"

--- a/app/src/test/java/com/example/app/BinLocatorUnitTest.kt
+++ b/app/src/test/java/com/example/app/BinLocatorUnitTest.kt
@@ -23,12 +23,12 @@ class BinLocatorUnitTest {
 
     @Test
     @org.junit.Ignore("Robolectric dependencies not available in CI")
-    fun debugMode_hidesSendButton() {
+    fun debugMode_disablesSendButton() {
         val intent = Intent(ApplicationProvider.getApplicationContext(), BinLocatorActivity::class.java)
         intent.putExtra("debug", true)
         val controller = Robolectric.buildActivity(BinLocatorActivity::class.java, intent).setup()
         val activity = controller.get()
         val button = activity.findViewById<android.widget.Button>(R.id.sendRecordButton)
-        assertEquals(android.view.View.GONE, button.visibility)
+        assertEquals(false, button.isEnabled)
     }
 }


### PR DESCRIPTION
## Summary
- refactor Bin Locator layout with side container for debug buttons
- always show Send Record button but disable when not ready
- widen Capture button
- update activity logic for new container and disable logic
- adjust UI and unit tests
- track task

## Testing
- `./gradlew lint` *(fails: SDK location not found)*
- `./gradlew testDebugUnitTest` *(fails: SDK location not found)*
- `./gradlew connectedDebugAndroidTest` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6874b25c57348328b42ee1185cb84d55