### PR TITLE
Refactor Bin Locator action buttons

### DIFF
--- a/app/src/main/java/com/example/app/BinLocatorActivity.kt
+++ b/app/src/main/java/com/example/app/BinLocatorActivity.kt
@@ -93,10 +93,10 @@ class BinLocatorActivity : AppCompatActivity() {
             showBatchButton.visibility = View.VISIBLE
         }
         if (debugMode) {
-            sendRecordButton.visibility = View.GONE
             showOcrButton.visibility = View.VISIBLE
             showCropButton.visibility = View.VISIBLE
         }
+        sendRecordButton.isEnabled = false
 
         captureButton.setOnClickListener { takePhoto() }
         getReleaseButton.setOnClickListener { scanRelease() }
@@ -270,16 +270,13 @@ class BinLocatorActivity : AppCompatActivity() {
     }
 
     private fun updateSendRecordVisibility() {
-        if (debugMode) {
-            sendRecordButton.visibility = View.GONE
-            return
-        }
         val textLines = ocrTextView.text.split("\n")
         val hasRoll = textLines.any { it.startsWith("Roll#:") }
         val hasCust = textLines.any { it.startsWith("Cust:") }
         val hasBin = textLines.any { it.contains("BIN=") }
         val batchReady = batchMode && batchItems.isNotEmpty() && batchItems.all { it.bin != null }
-        sendRecordButton.visibility = if ((hasRoll && hasCust && hasBin) || batchReady) View.VISIBLE else View.GONE
+        val enabled = !debugMode && ((hasRoll && hasCust && hasBin) || batchReady)
+        sendRecordButton.isEnabled = enabled
     }
 
     private fun sendRecord() {
@@ -315,7 +312,7 @@ class BinLocatorActivity : AppCompatActivity() {
             batchItems.clear()
             ocrTextView.text = ""
             actionButtons.visibility = View.GONE
-            sendRecordButton.visibility = View.GONE
+            updateSendRecordVisibility()
         }
     }
 

--- a/app/src/main/res/layout/activity_bin_locator.xml
+++ b/app/src/main/res/layout/activity_bin_locator.xml
@@ -22,7 +22,7 @@
         android:orientation="horizontal"
         android:visibility="gone"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintEnd_toStartOf="@+id/showButtonsContainer"
         app:layout_constraintTop_toBottomOf="@id/ocrTextView">
 
         <Button
@@ -39,37 +39,44 @@
             android:layout_weight="1"
             android:text="Set Bin" />
 
-        <Button
-            android:id="@+id/sendRecordButton"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_weight="1"
-            android:visibility="gone"
-            android:text="Send Record" />
+    </LinearLayout>
+
+    <LinearLayout
+        android:id="@+id/showButtonsContainer"
+        android:layout_width="wrap_content"
+        android:layout_height="0dp"
+        android:orientation="vertical"
+        app:layout_constraintTop_toBottomOf="@id/actionButtons"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent">
 
         <Button
             android:id="@+id/showOcrButton"
-            android:layout_width="0dp"
+            android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_weight="1"
-            android:visibility="gone"
-            android:text="Show OCR" />
+            android:text="Show OCR"
+            android:visibility="gone" />
 
         <Button
             android:id="@+id/showCropButton"
-            android:layout_width="0dp"
+            android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_weight="1"
-            android:visibility="gone"
-            android:text="Show Crop" />
+            android:text="Show Crop"
+            android:visibility="gone" />
 
         <Button
             android:id="@+id/showBatchButton"
-            android:layout_width="0dp"
+            android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_weight="1"
             android:visibility="gone"
             android:text="Show Items" />
+
+        <Button
+            android:id="@+id/sendRecordButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:enabled="false"
+            android:text="Send Record" />
     </LinearLayout>
 
     <FrameLayout
@@ -79,7 +86,7 @@
         app:layout_constraintTop_toBottomOf="@id/actionButtons"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent">
+        app:layout_constraintEnd_toStartOf="@id/showButtonsContainer">
 
         <androidx.camera.view.PreviewView
             android:id="@+id/viewFinder"
@@ -102,7 +109,7 @@
 
     <Button
         android:id="@+id/captureButton"
-        android:layout_width="wrap_content"
+        android:layout_width="120dp"
         android:layout_height="wrap_content"
         android:text="Capture"
         app:layout_constraintBottom_toBottomOf="parent"


### PR DESCRIPTION
## Summary
- move Show buttons and Send Record button into a vertical side container
- keep Send Record always visible and disable it until data is ready
- display Show OCR and Show Crop only in debug mode
- make Capture button wider

## Testing
- `./gradlew lint` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6874b25c57348328b42ee1185cb84d55