### PR TITLE
Ensure first item included and adjust button spacing

### DIFF
--- a/app/src/main/java/com/example/app/BinLocatorActivity.kt
+++ b/app/src/main/java/com/example/app/BinLocatorActivity.kt
@@ -33,6 +33,7 @@ import com.example.app.LabelCropper
 import com.example.app.ZoomUtils
 import com.example.app.OcrParser
 import com.example.app.RecordUploader
+import com.example.app.CheckoutUtils
 import android.util.Log
 import java.io.File
 import java.util.concurrent.ExecutorService
@@ -483,8 +484,9 @@ class BinLocatorActivity : AppCompatActivity() {
     }
 
     private fun showBatchItems() {
-        if (batchItems.isEmpty()) return
-        val message = batchItems.joinToString("\n") { "${it.roll} - ${it.customer} - ${it.bin ?: "no bin"}" }
+        val items = CheckoutUtils.buildPayload(ocrTextView.text.split("\n"), batchItems)
+        if (items.isEmpty()) return
+        val message = items.joinToString("\n") { "${it.roll} - ${it.customer} - ${it.bin ?: "no bin"}" }
         runOnUiThread {
             androidx.appcompat.app.AlertDialog.Builder(this)
                 .setTitle("Queued Items")

--- a/app/src/main/java/com/example/app/CheckoutUtils.kt
+++ b/app/src/main/java/com/example/app/CheckoutUtils.kt
@@ -1,0 +1,18 @@
+package com.example.app
+
+/** Utility functions for checkout logic. */
+object CheckoutUtils {
+    /**
+     * Builds the final list of checkout records including the current lines and queued items.
+     */
+    fun buildPayload(lines: List<String>, queued: List<BatchRecord>): List<BatchRecord> {
+        val roll = lines.firstOrNull { it.startsWith("Roll#:") }?.substringAfter(":")?.trim()
+        val cust = lines.firstOrNull { it.startsWith("Cust:") }?.substringAfter(":")?.trim()
+        val result = mutableListOf<BatchRecord>()
+        if (roll != null && cust != null) {
+            result += BatchRecord(roll, cust, null)
+        }
+        result.addAll(queued)
+        return result
+    }
+}

--- a/app/src/main/res/layout/activity_bin_locator.xml
+++ b/app/src/main/res/layout/activity_bin_locator.xml
@@ -157,6 +157,7 @@
         android:layout_width="307dp"
         android:layout_height="70dp"
         android:layout_marginStart="8dp"
+        android:layout_marginEnd="8dp"
         android:text="Capture"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toStartOf="@+id/addItemButton"

--- a/app/src/test/java/com/example/app/CheckoutUtilsTest.kt
+++ b/app/src/test/java/com/example/app/CheckoutUtilsTest.kt
@@ -1,0 +1,26 @@
+package com.example.app
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class CheckoutUtilsTest {
+    @Test
+    fun buildPayload_includesCurrentAndQueued() {
+        val lines = listOf("Roll#: 1", "Cust: A")
+        val queued = listOf(BatchRecord("2", "B"))
+        val payload = CheckoutUtils.buildPayload(lines, queued)
+        assertEquals(2, payload.size)
+        assertEquals("1", payload[0].roll)
+        assertEquals("A", payload[0].customer)
+        assertEquals("2", payload[1].roll)
+    }
+
+    @Test
+    fun buildPayload_missingCurrentReturnsQueued() {
+        val lines = listOf("Cust: A")
+        val queued = listOf(BatchRecord("2", "B"))
+        val payload = CheckoutUtils.buildPayload(lines, queued)
+        assertEquals(1, payload.size)
+        assertEquals("2", payload[0].roll)
+    }
+}


### PR DESCRIPTION
## Summary
- include currently displayed roll/customer when viewing or sending batch and checkout items
- factor out checkout payload logic into `CheckoutUtils`
- space Add Item button away from the capture button
- add unit tests for checkout payload helper

## Testing
- `./gradlew lint`
- `./gradlew testDebugUnitTest`


------
https://chatgpt.com/codex/tasks/task_e_68789d35e9c083288d8ab0e5ae98fef4