### PR TITLE
Add API key header to upload requests

### DIFF
--- a/AppFeatures.txt
+++ b/AppFeatures.txt
@@ -26,7 +26,8 @@ The project is a minimal Android application written in Kotlin. Below are all of
   and "Floor BR/BL". Selected bins set `BIN=<value>` on the roll number line,
   replacing any previous value.
 * When roll, customer and bin are all present a **Send Record** button appears
-  allowing upload to the warehouse database. On success the text view clears.
+  allowing upload to the warehouse database. Each record is POSTed with an
+  `X-API-Key` header. On success the text view clears.
   If the server responds with an error, its message is displayed to the user.
 * A **Debug mode** checkbox on the main screen disables sending and adds **Show
  OCR**, **Show Crop**, and **Show Log** buttons. The OCR dialog lists raw lines with bounding
@@ -46,6 +47,7 @@ The project is a minimal Android application written in Kotlin. Below are all of
 ## 3. Checkout Items Activity
 * Uses the same camera and OCR pipeline as the Bin Locator but operates only in batch mode.
 * Queued roll/customer pairs are sent to `checkout.php` with the user's PIN included as `last_user` after confirmation.
+  Each POST includes an `X-API-Key` header for authentication.
 * A confirmation dialog shows how many items will be checked out.
 * When debug mode is enabled a **Show Log** button displays collected debug messages.
 

--- a/README.md
+++ b/README.md
@@ -86,7 +86,8 @@ This app relies on Material Components. A custom theme extending `Theme.Material
   roll number is removed so users see only the numeric portion.
 - Once roll, customer and bin are present a **Send Record** button appears when
   batch mode is enabled. In default mode a full-screen bin menu pops up and
-  selecting a value uploads immediately. If the server returns an error, the
+  selecting a value uploads immediately. Requests are POSTed with an
+  `X-API-Key` header for authentication. If the server returns an error, the
   provided message is shown instead of a generic failure.
  - A **Debug mode** checkbox on the main screen launches Bin Locator with sending
   disabled. Additional **Show OCR**, **Show Crop** and **Show Log** buttons reveal raw text
@@ -106,5 +107,7 @@ This app relies on Material Components. A custom theme extending `Theme.Material
   correct PIN is provided.
 - A **Checkout Items** option on the main screen opens a camera screen similar
   to Bin Locator. Items can be queued and confirmed with a Checkout button which
-  posts them with the user's PIN (sent as `last_user`) to `checkout.php`. When debug mode is enabled
-  this screen also offers a **Show Log** button for reviewing debug messages.
+  posts them with the user's PIN (sent as `last_user`) to `checkout.php`. All
+  uploads now include an `X-API-Key` header for authentication.
+  When debug mode is enabled this screen also offers a **Show Log** button for
+  reviewing debug messages.

--- a/app/src/main/java/com/example/app/CheckoutUploader.kt
+++ b/app/src/main/java/com/example/app/CheckoutUploader.kt
@@ -42,6 +42,7 @@ object CheckoutUploader {
                         "Content-Type",
                         "application/x-www-form-urlencoded"
                     )
+                    setRequestProperty("X-API-Key", "4!qCj8eD@kP7z#hFwL$yR6bN*tE2s")
                 }
 
                 val body = buildString {

--- a/app/src/main/java/com/example/app/RecordUploader.kt
+++ b/app/src/main/java/com/example/app/RecordUploader.kt
@@ -27,6 +27,7 @@ object RecordUploader {
                     requestMethod = "POST"
                     doOutput = true
                     setRequestProperty("Content-Type", "application/x-www-form-urlencoded")
+                    setRequestProperty("X-API-Key", "4!qCj8eD@kP7z#hFwL$yR6bN*tE2s")
                 }
 
                 val body = "roll_num=" + URLEncoder.encode(roll, "UTF-8") +


### PR DESCRIPTION
## Summary
- send `X-API-Key` header when uploading records or checking out items
- document new header in README and AppFeatures

## Testing
- `./gradlew lint testDebugUnitTest` *(fails: missing Android SDK licenses)*

------
https://chatgpt.com/codex/tasks/task_e_6878a87347708328b976e10e0c3f6081