### PR TITLE
Support target aspect ratio tuning

### DIFF
--- a/AppFeatures.txt
+++ b/AppFeatures.txt
@@ -13,7 +13,7 @@ The project is a minimal Android application written in Kotlin. Below are all of
 * Provides a camera preview using **CameraX**. When the screen loads it requests the camera permission if needed and starts the camera.
 * Screen orientation is fixed to portrait, simplifying camera alignment regardless of device rotation.
 * Includes a **Capture** button. When tapped it captures a photo to a temporary file, rotates the image based on the current setting and runs **ML Kit Text Recognition**.
-* Shows a green **TOP** label with a bounding box overlay covering about 60% of the screen width so users align text correctly. The captured image is cropped to this region before processing.
+* Shows a green **TOP** label with a bounding box overlay covering about 60% of the screen width. The overlay uses a target aspect ratio (default 8.5:3.625) from the tuning parameters so alignment matches the expected label size. The captured image is cropped to this region before processing.
 * The cropped label is perspective corrected with OpenCV before OCR for improved accuracy.
 * Supports pinch-to-zoom on the preview with a slider. The preview starts at 40% zoom and there is no reset button.
 * Recognised text appears in a persistent text view at the top of the screen.

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ This app relies on Material Components. A custom theme extending `Theme.Material
 ## Features
 
  - Camera-based **Bin Locator** with a bounding box overlay guiding where to place
-  text for OCR. The box now covers about **60%** of the screen width for easier framing.
+  text for OCR. The box spans about **60%** of the screen width and uses a configurable target aspect ratio (default 8.5:3.625) so the crop matches the expected label shape.
 - Captured images are cropped to this box and processed with ML Kit text
   recognition.
 - Camera preview supports pinch-to-zoom with a slider. The preview starts at a

--- a/TASK.md
+++ b/TASK.md
@@ -45,3 +45,4 @@
 ## [2025-07-17] Log roll & customer in checkout debug log - DONE
 ## [2025-07-18] Add manual Input Item dialog
 ## [2025-07-18] Send PIN as last_user on all POST requests - DONE
+## [2025-07-18] Add target aspect ratio parameter for cropping

--- a/app/src/main/java/com/example/app/BinLocatorActivity.kt
+++ b/app/src/main/java/com/example/app/BinLocatorActivity.kt
@@ -193,7 +193,7 @@ class BinLocatorActivity : AppCompatActivity() {
                     crop.height()
                 )
                 dLog("Initial crop ${crop.width()}x${crop.height()}")
-                val warped = LabelCropper.cropLabel(cropped, overlay.aspectRatio())
+                val warped = LabelCropper.cropLabel(cropped)
                 dLog("Warped size ${warped.width}x${warped.height}")
                 val processed = ImageUtils.toGrayscale(warped)
                 lastBitmap = processed
@@ -408,6 +408,7 @@ class BinLocatorActivity : AppCompatActivity() {
         val eps = view.findViewById<com.google.android.material.slider.Slider>(R.id.epsilonSlider)
         val minArea = view.findViewById<com.google.android.material.slider.Slider>(R.id.minAreaSlider)
         val ratioTol = view.findViewById<com.google.android.material.slider.Slider>(R.id.ratioSlider)
+        val targetRatioEdit = view.findViewById<android.widget.EditText>(R.id.targetRatioEdit)
         val widthEdit = view.findViewById<android.widget.EditText>(R.id.widthEdit)
         val heightEdit = view.findViewById<android.widget.EditText>(R.id.heightEdit)
         val lineHeight = view.findViewById<com.google.android.material.slider.Slider>(R.id.lineHeightSlider)
@@ -419,6 +420,7 @@ class BinLocatorActivity : AppCompatActivity() {
         eps.value = TuningParams.epsilon.toFloat()
         minArea.value = TuningParams.minAreaRatio
         ratioTol.value = TuningParams.ratioTolerance
+        targetRatioEdit.setText(TuningParams.targetRatio.toString())
         widthEdit.setText(TuningParams.outputWidth.toString())
         heightEdit.setText(TuningParams.outputHeight.toString())
         lineHeight.value = TuningParams.lineHeightPercent
@@ -436,6 +438,7 @@ class BinLocatorActivity : AppCompatActivity() {
             TuningParams.epsilon = eps.value.toDouble()
             TuningParams.minAreaRatio = minArea.value
             TuningParams.ratioTolerance = ratioTol.value
+            TuningParams.targetRatio = targetRatioEdit.text.toString().toFloatOrNull() ?: TuningParams.targetRatio
             TuningParams.outputWidth = widthEdit.text.toString().toIntOrNull() ?: TuningParams.outputWidth
             TuningParams.outputHeight = heightEdit.text.toString().toIntOrNull() ?: TuningParams.outputHeight
             TuningParams.lineHeightPercent = lineHeight.value

--- a/app/src/main/java/com/example/app/BoundingBoxOverlay.kt
+++ b/app/src/main/java/com/example/app/BoundingBoxOverlay.kt
@@ -10,7 +10,8 @@ import android.util.AttributeSet
 import android.view.View
 
 /**
- * Overlay view drawing a fixed landscape bounding box with orientation text.
+ * Overlay view drawing a landscape bounding box with orientation text. The
+ * aspect ratio is based on [TuningParams.targetRatio].
  */
 class BoundingBoxOverlay @JvmOverloads constructor(
     context: Context,
@@ -68,12 +69,12 @@ class BoundingBoxOverlay @JvmOverloads constructor(
     companion object {
         /**
          * Calculates the bounding box rectangle for the given view size.
-         * The box spans 60% of the view's width while maintaining a 34:15
-         * aspect ratio.
+         * The box spans 60% of the view's width while maintaining
+         * [TuningParams.targetRatio].
          */
         fun calculateBoxRect(viewWidth: Int, viewHeight: Int): RectF {
             val boxWidth = 0.6f * viewWidth
-            val boxHeight = boxWidth * 15f / 34f
+            val boxHeight = boxWidth / TuningParams.targetRatio
             val left = (viewWidth - boxWidth) / 2f
             val top = (viewHeight - boxHeight) / 2f
             return RectF(left, top, left + boxWidth, top + boxHeight)

--- a/app/src/main/java/com/example/app/CheckoutActivity.kt
+++ b/app/src/main/java/com/example/app/CheckoutActivity.kt
@@ -122,7 +122,7 @@ class CheckoutActivity : AppCompatActivity() {
                 val crop = overlay.mapToBitmapRect(rotated.width, rotated.height)
                 val cropped = Bitmap.createBitmap(rotated, crop.left, crop.top, crop.width(), crop.height())
                 dLog("Initial crop ${crop.width()}x${crop.height()}")
-                val warped = LabelCropper.cropLabel(cropped, overlay.aspectRatio())
+                val warped = LabelCropper.cropLabel(cropped)
                 dLog("Warped size ${warped.width}x${warped.height}")
                 val processed = ImageUtils.toGrayscale(warped)
                 if (debugMode) {

--- a/app/src/main/java/com/example/app/LabelCropper.kt
+++ b/app/src/main/java/com/example/app/LabelCropper.kt
@@ -16,11 +16,11 @@ object LabelCropper {
     private const val TAG = "LabelCropper"
 
     /**
-     * Finds the label rectangle closest to the given aspect ratio and
+     * Finds the label rectangle closest to [TuningParams.targetRatio] and
      * returns a perspective-warped bitmap. If detection fails the
      * original bitmap is returned.
      */
-    fun cropLabel(bitmap: Bitmap, aspect: Float): Bitmap {
+    fun cropLabel(bitmap: Bitmap): Bitmap {
         if (!OpenCVLoader.initDebug()) return bitmap
 
         val src = Mat()
@@ -47,6 +47,7 @@ object LabelCropper {
 
         val contours = mutableListOf<MatOfPoint>()
         Imgproc.findContours(edges, contours, Mat(), Imgproc.RETR_EXTERNAL, Imgproc.CHAIN_APPROX_SIMPLE)
+        val aspect = TuningParams.targetRatio
         Log.d(TAG, "Contours found: ${'$'}{contours.size}")
 
         var bestQuad: MatOfPoint2f? = null

--- a/app/src/main/java/com/example/app/TuningParams.kt
+++ b/app/src/main/java/com/example/app/TuningParams.kt
@@ -10,6 +10,8 @@ object TuningParams {
     var dilateKernel: Int = 3
     var epsilon: Double = 10.0
     var minAreaRatio: Float = 0.1f
+    /** Target width/height ratio of the label (e.g. 4:1 = 4.0). */
+    var targetRatio: Float = (8.5f / 3.625f)
     var ratioTolerance: Float = 0.1f
     var outputWidth: Int = 800
     var outputHeight: Int = 200

--- a/app/src/main/res/layout/dialog_tuning.xml
+++ b/app/src/main/res/layout/dialog_tuning.xml
@@ -97,6 +97,16 @@
         <TextView
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
+            android:text="Target Ratio" />
+        <EditText
+            android:id="@+id/targetRatioEdit"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:inputType="numberDecimal" />
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
             android:text="Output Width" />
         <EditText
             android:id="@+id/widthEdit"

--- a/app/src/test/java/com/example/app/BoundingBoxUtilTest.kt
+++ b/app/src/test/java/com/example/app/BoundingBoxUtilTest.kt
@@ -13,7 +13,7 @@ class BoundingBoxUtilTest {
     fun calculateRect_maintainsAspectRatio() {
         val rect = BoundingBoxOverlay.calculateBoxRect(1000, 800)
         val ratio = rect.width() / rect.height()
-        val expected = 34f / 15f
+        val expected = 8.5f / 3.625f
         assertEquals(expected, ratio, 0.01f)
     }
 

--- a/app/src/test/java/com/example/app/LabelCropperTest.kt
+++ b/app/src/test/java/com/example/app/LabelCropperTest.kt
@@ -12,7 +12,7 @@ class LabelCropperTest {
     @org.junit.Ignore("OpenCV not available in CI")
     fun cropLabel_returnsBitmap() {
         val bmp = Bitmap.createBitmap(100, 50, Bitmap.Config.ARGB_8888)
-        val result = LabelCropper.cropLabel(bmp, 2f)
+        val result = LabelCropper.cropLabel(bmp)
         assertTrue(result.width > 0 && result.height > 0)
     }
 }

--- a/app/src/test/java/com/example/app/TuningParamsTest.kt
+++ b/app/src/test/java/com/example/app/TuningParamsTest.kt
@@ -13,6 +13,7 @@ class TuningParamsTest {
         assertEquals(10.0, TuningParams.epsilon, 0.001)
         assertEquals(0.1f, TuningParams.minAreaRatio)
         assertEquals(0.1f, TuningParams.ratioTolerance)
+        assertEquals(8.5f / 3.625f, TuningParams.targetRatio, 0.001f)
         assertEquals(800, TuningParams.outputWidth)
         assertEquals(200, TuningParams.outputHeight)
         assertEquals(0.75f, TuningParams.lineHeightPercent)


### PR DESCRIPTION
## Summary
- add `targetRatio` parameter to TuningParams
- compute label aspect using the tuning value in LabelCropper
- adjust bounding box overlay and tests to use the tunable ratio
- expose target ratio field in the tuning dialog and read/save it
- document the configurable ratio in README and AppFeatures
- log task for target ratio parameter in TASK.md

## Testing
- `./gradlew lint` *(fails: SDK location not found)*
- `./gradlew testDebugUnitTest` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_687940eab8288328b29e2bdd81598b88