### PR TITLE
Add developer mode PRP

### DIFF
--- a/AppFeatures.txt
+++ b/AppFeatures.txt
@@ -35,6 +35,8 @@ The project is a minimal Android application written in Kotlin. Below are all of
  box heights. **Show Crop** saves the grayscale warped label image used for OCR before
  displaying it, and **Show Log** shows collected debug messages so preprocessing is easy to inspect.
 * A **Tune Pipeline** button in debug mode lets developers adjust OCR pipeline parameters with sliders for the current session only.
+* Entering PIN `8789` shows a **Developer** button instead of the debug checkbox. This launches a screen with the debug toggle and a **Preprocess Debug** tool.
+* **Preprocess Debug** captures an image, applies the preprocessing pipeline and displays the result without running OCR.
 * A **Batch mode** checkbox determines the workflow. When unchecked a full-screen
   bin menu appears automatically once roll and customer are parsed. Selecting a
   value sends the record immediately and the capture and zoom controls are hidden

--- a/PRPs/developer_mode.md
+++ b/PRPs/developer_mode.md
@@ -1,0 +1,190 @@
+name: "Developer Mode and Preprocess Debug"
+description: |
+  ## Purpose
+  Introduce a developer-only workflow triggered by PIN 8789. Developer mode centralizes all debug and tuning features and exposes a new preprocessing debug screen.
+
+  ## Core Principles
+  1. **Context is King**: rely on MainActivity and BinLocator patterns.
+  2. **Validation Loops**: Gradle lint plus unit and instrumentation tests.
+  3. **Information Dense**: follow existing Kotlin style.
+  4. **Progressive Success**: implement login flag, developer UI, then new activity.
+  5. **Global rules**: follow CODEX.md guidelines.
+---
+## Goal
+Add a Developer login path that unlocks a Developer screen containing the Debug mode toggle and access to a new Preprocess Debug module. This module displays the OCR preprocessing result immediately without running ML Kit.
+## Why
+- **Business value**: enables on-device pipeline investigation without releasing debug tools to regular users.
+- **Integration**: builds upon existing MainActivity login flow and BinLocatorActivity debug/tune features.
+- **Problem solved**: developers need to inspect preprocessing output to tweak parameters.
+## What
+- Detect PIN 8789 at login and enable developer features.
+- Replace the Debug checkbox on the home screen with a Developer button appearing only when in developer mode.
+- Developer screen hosts the Debug checkbox and a button launching Preprocess Debug.
+- Preprocess Debug captures an image, crops and converts it like Bin Locator but stops before ML Kit, showing the processed image at the top.
+- Only Capture and Tune buttons are present in Preprocess Debug.
+
+### Success Criteria
+- [ ] Entering PIN 8789 reveals Developer button.
+- [ ] Debug checkbox lives inside Developer screen and still passes flag to camera modules.
+- [ ] Preprocess Debug shows processed image automatically and omits ML Kit.
+- [ ] Gradle lint and tests pass.
+## All Needed Context
+
+### Documentation & References (list all context needed to implement the feature)
+```yaml
+- url: https://developer.android.com/topic/architecture
+  why: recommended activity structure and navigation patterns.
+- url: https://github.com/android/nowinandroid/blob/main/docs/ArchitectureLearningJourney.md
+  why: clean architecture best practices.
+- file: app/src/main/java/com/example/app/MainActivity.kt
+  why: current login flow and intent extras.
+- file: app/src/main/java/com/example/app/BinLocatorActivity.kt
+  why: debugMode implementation and tuning dialog example.
+- file: app/src/main/java/com/example/app/CheckoutActivity.kt
+  why: separate activity using same OCR pipeline.
+- file: app/src/main/java/com/example/app/TuningParams.kt
+  why: runtime tuning parameters referenced by tune dialog.
+- file: examples/image_processing/MainActivity.java
+  why: example of displaying processed image.
+```
+
+### Current Codebase tree (run `tree` in the root of the project) to get an overview of the codebase
+```bash
+.
+├── app
+│   └── src
+│       ├── main
+│       │   ├── java/com/example/app
+│       │   └── res
+│       ├── test/java/com/example/app
+│       └── androidTest/java/com/example/app
+```
+
+### Desired Codebase tree with files to be added and responsibility of file
+```bash
+app/src/main/res/layout/activity_main.xml          # remove debugCheckBox, add developerButton
+app/src/main/java/com/example/app/MainActivity.kt  # detect PIN 8789, launch DeveloperActivity
+app/src/main/res/layout/activity_developer.xml     # UI with debugCheckBox and preprocessButton
+app/src/main/java/com/example/app/DeveloperActivity.kt # handles debug flag and navigation
+app/src/main/res/layout/activity_preprocess_debug.xml  # preview plus processed ImageView
+app/src/main/java/com/example/app/PreprocessDebugActivity.kt # capture and show preprocessed image
+app/src/test/java/com/example/app/DeveloperModeTest.kt  # unit tests for login logic
+app/src/androidTest/java/com/example/app/PreprocessDebugUiTest.kt # verify processed image shows
+```
+
+### Known Gotchas of our codebase & Library Quirks
+```kotlin
+// Network operations must not run on the main thread.
+// Robolectric tests are ignored in CI; annotate with @Ignore.
+// Intent extras default to false if missing; handle explicitly.
+```
+
+## Implementation Blueprint
+
+### Data models and structure
+No new data models. Introduce `var developerMode = false` in MainActivity and pass a boolean `debug` extra from DeveloperActivity. PreprocessDebugActivity uses existing `TuningParams` for adjustments.
+
+### list of tasks to be completed to fullfill the PRP in the order they should be completed
+```yaml
+Task 1:
+  MODIFY app/src/main/java/com/example/app/MainActivity.kt:
+    - After validating PIN, if pin == "8789" set developerMode = true and show developerButton.
+    - Launch DeveloperActivity from developerButton.
+    - When starting BinLocatorActivity or CheckoutActivity pass debug flag stored from DeveloperActivity.
+
+Task 2:
+  MODIFY app/src/main/res/layout/activity_main.xml:
+    - Remove debugCheckBox.
+    - Add Button id=developerButton below batchCheckBox, visibility=gone.
+
+Task 3:
+  CREATE app/src/main/res/layout/activity_developer.xml:
+    - Contains CheckBox id=debugCheckBox and Button id=preprocessButton.
+
+Task 4:
+  CREATE app/src/main/java/com/example/app/DeveloperActivity.kt:
+    - Manages debugCheckBox state.
+    - preprocessButton launches PreprocessDebugActivity.
+
+Task 5:
+  CREATE app/src/main/res/layout/activity_preprocess_debug.xml:
+    - PreviewView for camera and ImageView id=processedImage on top.
+    - Capture and Tune buttons only.
+
+Task 6:
+  CREATE app/src/main/java/com/example/app/PreprocessDebugActivity.kt:
+    - Replicate camera setup from BinLocatorActivity.
+    - After capturing, crop with LabelCropper and convert to grayscale.
+    - Display processed bitmap in processedImage without calling ML Kit.
+
+Task 7:
+  CREATE app/src/test/java/com/example/app/DeveloperModeTest.kt:
+    - Verify developerButton visible only with PIN 8789.
+    - Confirm debug flag passed to BinLocatorActivity.
+
+Task 8:
+  CREATE app/src/androidTest/java/com/example/app/PreprocessDebugUiTest.kt:
+    - Launch activity, trigger capture via reflection, assert processedImage visible.
+
+Task 9:
+  UPDATE README.md and AppFeatures.txt documenting developer mode and preprocessing debug.
+```
+
+### Per task pseudocode as needed added to each task
+```kotlin
+// Task 1 snippet
+if (entered == "8789") {
+    developerMode = true
+    developerButton.visibility = View.VISIBLE
+}
+
+// Task 6 snippet
+override fun onImageSaved(results: ImageCapture.OutputFileResults) {
+    val bmp = ImageUtils.decodeRotatedBitmap(photoFile)
+    val crop = overlay.mapToBitmapRect(bmp.width, bmp.height)
+    val warped = LabelCropper.cropLabel(
+        Bitmap.createBitmap(bmp, crop.left, crop.top, crop.width(), crop.height()),
+        bmp.width * bmp.height
+    )
+    val processed = ImageUtils.toGrayscale(warped)
+    runOnUiThread { processedImage.setImageBitmap(processed) }
+}
+```
+
+### Integration Points
+```yaml
+CONFIG: none
+DATABASE: none
+ROUTES: none
+```
+
+## Validation Loop
+
+### Level 1: Syntax & Style
+```bash
+./gradlew lint
+```
+
+### Level 2: Unit Tests
+```bash
+./gradlew testDebugUnitTest
+```
+
+### Level 3: Instrumentation Test
+```bash
+./gradlew connectedDebugAndroidTest
+```
+
+## Final validation Checklist
+- [ ] All tests pass: `./gradlew testDebugUnitTest connectedDebugAndroidTest`
+- [ ] No linting errors: `./gradlew lint`
+- [ ] README and AppFeatures updated
+
+---
+
+## Anti-Patterns to Avoid
+- ❌ Don't expose developer features without PIN check.
+- ❌ Don't run ML Kit in preprocessing debug.
+- ❌ Don't skip updating documentation.
+
+### PRP Confidence Score: 7/10

--- a/README.md
+++ b/README.md
@@ -101,6 +101,12 @@ This app relies on Material Components. A custom theme extending `Theme.Material
   passed to ML Kit, and a dialog with collected debug logs for troubleshooting.
 - A **Tune Pipeline** button in debug mode opens sliders and fields for
   adjusting OCR preprocessing values during the current session.
+- Entering PIN **8789** unlocks a Developer screen with the debug toggle and a
+  **Preprocess Debug** option. This screen centralises tools only meant for
+  developers.
+- **Preprocess Debug** captures an image and immediately shows the warped
+  grayscale result without running ML Kit, letting developers inspect tuning
+  effects.
 - A **Batch mode** checkbox on the main screen controls whether captures queue
   multiple items or use a single-record flow. When unchecked a full-screen
   **Bins** menu appears once roll and customer are recognised; choosing a bin

--- a/TASK.md
+++ b/TASK.md
@@ -47,3 +47,5 @@
 ## [2025-07-18] Send PIN as last_user on all POST requests - DONE
 ## [2025-07-18] Add target aspect ratio parameter for cropping
 ## [2025-07-19] Create setup script for Codex environment - DONE
+## [2025-07-20] Generate PRP for Developer Mode and Preprocess Debug - DONE
+## [2025-07-20] Implement Developer Mode and Preprocess Debug

--- a/app/src/androidTest/java/com/example/app/PreprocessDebugUiTest.kt
+++ b/app/src/androidTest/java/com/example/app/PreprocessDebugUiTest.kt
@@ -1,0 +1,29 @@
+package com.example.app
+
+import android.content.Intent
+import androidx.test.core.app.ActivityScenario
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
+import androidx.test.espresso.matcher.ViewMatchers.withId
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class PreprocessDebugUiTest {
+    @Test
+    fun capture_showsProcessedImage() {
+        val intent = Intent(InstrumentationRegistry.getInstrumentation().targetContext, PreprocessDebugActivity::class.java)
+        ActivityScenario.launch<PreprocessDebugActivity>(intent).use { scenario ->
+            scenario.onActivity { activity ->
+                val method = PreprocessDebugActivity::class.java.getDeclaredMethod("takePhoto")
+                method.isAccessible = true
+                method.invoke(activity)
+            }
+            InstrumentationRegistry.getInstrumentation().waitForIdleSync()
+            onView(withId(R.id.processedImage)).check(matches(isDisplayed()))
+        }
+    }
+}

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -16,6 +16,11 @@
             android:name=".CheckoutActivity"
             android:screenOrientation="portrait" />
         <activity
+            android:name=".DeveloperActivity" />
+        <activity
+            android:name=".PreprocessDebugActivity"
+            android:screenOrientation="portrait" />
+        <activity
             android:name=".MainActivity"
             android:exported="true">
             <intent-filter>

--- a/app/src/main/java/com/example/app/DeveloperActivity.kt
+++ b/app/src/main/java/com/example/app/DeveloperActivity.kt
@@ -1,0 +1,28 @@
+package com.example.app
+
+import android.content.Intent
+import android.os.Bundle
+import android.widget.Button
+import android.widget.CheckBox
+import androidx.appcompat.app.AppCompatActivity
+
+/** Activity showing developer options. */
+class DeveloperActivity : AppCompatActivity() {
+    private lateinit var debugCheckBox: CheckBox
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_developer)
+        debugCheckBox = findViewById(R.id.debugCheckBox)
+        debugCheckBox.isChecked = intent.getBooleanExtra("debug", false)
+        findViewById<Button>(R.id.preprocessButton).setOnClickListener {
+            startActivity(Intent(this, PreprocessDebugActivity::class.java))
+        }
+    }
+
+    override fun finish() {
+        val data = Intent().putExtra("debug", debugCheckBox.isChecked)
+        setResult(RESULT_OK, data)
+        super.finish()
+    }
+}

--- a/app/src/main/java/com/example/app/MainActivity.kt
+++ b/app/src/main/java/com/example/app/MainActivity.kt
@@ -3,31 +3,48 @@ package com.example.app
 import android.content.Intent
 import android.os.Bundle
 import android.text.InputType
+import android.view.View
 import android.widget.Button
 import android.widget.CheckBox
 import android.widget.EditText
 import android.widget.Toast
 import androidx.appcompat.app.AlertDialog
+import androidx.activity.result.ActivityResultLauncher
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AppCompatActivity
 
 class MainActivity : AppCompatActivity() {
     private lateinit var binButton: Button
     private lateinit var checkoutButton: Button
+    private lateinit var developerButton: Button
     private var allowedPins: Set<String> = emptySet()
     private var pin: String = ""
+    private var developerMode: Boolean = false
+    private var debugFlag: Boolean = false
+    private lateinit var devLauncher: ActivityResultLauncher<Intent>
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
         val batchCheckBox = findViewById<CheckBox>(R.id.batchCheckBox)
-        val debugCheckBox = findViewById<CheckBox>(R.id.debugCheckBox)
+        developerButton = findViewById(R.id.developerButton)
+        developerButton.setOnClickListener {
+            val intent = Intent(this, DeveloperActivity::class.java)
+            intent.putExtra("debug", debugFlag)
+            devLauncher.launch(intent)
+        }
+        devLauncher = registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
+            if (result.resultCode == RESULT_OK) {
+                debugFlag = result.data?.getBooleanExtra("debug", false) ?: false
+            }
+        }
         binButton = findViewById(R.id.binLocatorButton)
         checkoutButton = findViewById(R.id.checkoutButton)
         binButton.isEnabled = false
         checkoutButton.isEnabled = false
         binButton.setOnClickListener {
             val intent = Intent(this, BinLocatorActivity::class.java)
-            intent.putExtra("debug", debugCheckBox.isChecked)
+            intent.putExtra("debug", debugFlag)
             intent.putExtra("batch", batchCheckBox.isChecked)
             intent.putExtra("pin", pin)
             startActivity(intent)
@@ -36,7 +53,7 @@ class MainActivity : AppCompatActivity() {
             val intent = Intent(this, CheckoutActivity::class.java)
             intent.putExtra("pin", pin)
             intent.putExtra("batch", true)
-            intent.putExtra("debug", debugCheckBox.isChecked)
+            intent.putExtra("debug", debugFlag)
             startActivity(intent)
         }
 
@@ -58,17 +75,24 @@ class MainActivity : AppCompatActivity() {
             .setView(input)
             .setCancelable(false)
             .setPositiveButton("OK") { _, _ ->
-                val entered = input.text.toString().trim()
-                if (entered.length == 4 && allowedPins.contains(entered)) {
-                    pin = entered
-                    binButton.isEnabled = true
-                    checkoutButton.isEnabled = true
-                } else {
-                    Toast.makeText(this, "Invalid PIN", Toast.LENGTH_SHORT).show()
-                    showPinDialog()
-                }
+                onPinEntered(input.text.toString().trim())
             }
             .setNegativeButton("Exit") { _, _ -> finish() }
             .show()
+    }
+
+    internal fun onPinEntered(entered: String) {
+        if (entered.length == 4 && allowedPins.contains(entered)) {
+            pin = entered
+            binButton.isEnabled = true
+            checkoutButton.isEnabled = true
+            if (entered == "8789") {
+                developerMode = true
+                developerButton.visibility = View.VISIBLE
+            }
+        } else {
+            Toast.makeText(this, "Invalid PIN", Toast.LENGTH_SHORT).show()
+            showPinDialog()
+        }
     }
 }

--- a/app/src/main/java/com/example/app/PreprocessDebugActivity.kt
+++ b/app/src/main/java/com/example/app/PreprocessDebugActivity.kt
@@ -1,0 +1,151 @@
+package com.example.app
+
+import android.Manifest
+import android.content.pm.PackageManager
+import android.graphics.Bitmap
+import android.os.Bundle
+import android.view.View
+import android.widget.Button
+import android.widget.ImageView
+import androidx.appcompat.app.AppCompatActivity
+import androidx.camera.core.ImageCapture
+import androidx.camera.core.ImageCaptureException
+import androidx.camera.lifecycle.ProcessCameraProvider
+import androidx.camera.view.LifecycleCameraController
+import androidx.camera.view.PreviewView
+import androidx.core.app.ActivityCompat
+import androidx.core.content.ContextCompat
+import java.io.File
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors
+
+/** Activity for inspecting OCR preprocessing result. */
+class PreprocessDebugActivity : AppCompatActivity() {
+    private lateinit var previewView: PreviewView
+    private lateinit var overlay: BoundingBoxOverlay
+    private lateinit var processedImage: ImageView
+    private lateinit var captureButton: Button
+    private lateinit var tuneButton: Button
+    private lateinit var cameraExecutor: ExecutorService
+    private lateinit var controller: LifecycleCameraController
+    private var cameraProvider: ProcessCameraProvider? = null
+
+    private val CAMERA_PERMISSION = Manifest.permission.CAMERA
+    private val REQUEST_CAMERA_PERMISSION = 3001
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        requestedOrientation = android.content.pm.ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
+        setContentView(R.layout.activity_preprocess_debug)
+        previewView = findViewById(R.id.viewFinder)
+        overlay = findViewById(R.id.boundingBox)
+        processedImage = findViewById(R.id.processedImage)
+        captureButton = findViewById(R.id.captureButton)
+        tuneButton = findViewById(R.id.tuneButton)
+        cameraExecutor = Executors.newSingleThreadExecutor()
+
+        captureButton.setOnClickListener { takePhoto() }
+        tuneButton.setOnClickListener { showTuningDialog() }
+
+        if (ActivityCompat.checkSelfPermission(this, CAMERA_PERMISSION) == PackageManager.PERMISSION_GRANTED) {
+            startCamera()
+        } else {
+            ActivityCompat.requestPermissions(this, arrayOf(CAMERA_PERMISSION), REQUEST_CAMERA_PERMISSION)
+        }
+    }
+
+    private fun startCamera() {
+        val future = ProcessCameraProvider.getInstance(this)
+        future.addListener({
+            cameraProvider = future.get()
+            controller = LifecycleCameraController(this).apply {
+                setEnabledUseCases(LifecycleCameraController.IMAGE_CAPTURE)
+                bindToLifecycle(this@PreprocessDebugActivity)
+            }
+            previewView.controller = controller
+        }, ContextCompat.getMainExecutor(this))
+    }
+
+    private fun takePhoto() {
+        val photoFile = File.createTempFile("temp", ".jpg", cacheDir)
+        val options = ImageCapture.OutputFileOptions.Builder(photoFile).build()
+        controller.takePicture(options, cameraExecutor, object : ImageCapture.OnImageSavedCallback {
+            override fun onError(exception: ImageCaptureException) {
+                exception.printStackTrace()
+            }
+
+            override fun onImageSaved(outputFileResults: ImageCapture.OutputFileResults) {
+                val bmp = ImageUtils.decodeRotatedBitmap(photoFile)
+                val crop = overlay.mapToBitmapRect(bmp.width, bmp.height)
+                val warped = LabelCropper.cropLabel(
+                    Bitmap.createBitmap(bmp, crop.left, crop.top, crop.width(), crop.height()),
+                    bmp.width * bmp.height
+                )
+                val processed = ImageUtils.toGrayscale(warped)
+                runOnUiThread { processedImage.setImageBitmap(processed) }
+            }
+        })
+    }
+
+    private fun showTuningDialog() {
+        val view = layoutInflater.inflate(R.layout.dialog_tuning, null)
+        val blur = view.findViewById<com.google.android.material.slider.Slider>(R.id.blurSlider)
+        val cannyLow = view.findViewById<com.google.android.material.slider.Slider>(R.id.cannyLowSlider)
+        val cannyHigh = view.findViewById<com.google.android.material.slider.Slider>(R.id.cannyHighSlider)
+        val dilate = view.findViewById<com.google.android.material.slider.Slider>(R.id.dilateSlider)
+        val eps = view.findViewById<com.google.android.material.slider.Slider>(R.id.epsilonSlider)
+        val minArea = view.findViewById<com.google.android.material.slider.Slider>(R.id.minAreaSlider)
+        val ratioTol = view.findViewById<com.google.android.material.slider.Slider>(R.id.ratioSlider)
+        val targetRatioEdit = view.findViewById<android.widget.EditText>(R.id.targetRatioEdit)
+        val widthEdit = view.findViewById<android.widget.EditText>(R.id.widthEdit)
+        val heightEdit = view.findViewById<android.widget.EditText>(R.id.heightEdit)
+        val lineHeight = view.findViewById<com.google.android.material.slider.Slider>(R.id.lineHeightSlider)
+
+        blur.value = TuningParams.blurKernel.toFloat()
+        cannyLow.value = TuningParams.cannyLow.toFloat()
+        cannyHigh.value = TuningParams.cannyHigh.toFloat()
+        dilate.value = TuningParams.dilateKernel.toFloat()
+        eps.value = TuningParams.epsilon.toFloat()
+        minArea.value = TuningParams.minAreaRatio
+        ratioTol.value = TuningParams.ratioTolerance
+        targetRatioEdit.setText(TuningParams.targetRatio.toString())
+        widthEdit.setText(TuningParams.outputWidth.toString())
+        heightEdit.setText(TuningParams.outputHeight.toString())
+        lineHeight.value = TuningParams.lineHeightPercent
+
+        val dialog = androidx.appcompat.app.AlertDialog.Builder(this)
+            .setTitle("Tune Pipeline")
+            .setView(view)
+            .create()
+
+        view.findViewById<Button>(R.id.applyButton).setOnClickListener {
+            TuningParams.blurKernel = blur.value.toInt()
+            TuningParams.cannyLow = cannyLow.value.toInt()
+            TuningParams.cannyHigh = cannyHigh.value.toInt()
+            TuningParams.dilateKernel = dilate.value.toInt()
+            TuningParams.epsilon = eps.value.toDouble()
+            TuningParams.minAreaRatio = minArea.value
+            TuningParams.ratioTolerance = ratioTol.value
+            TuningParams.targetRatio = targetRatioEdit.text.toString().toFloatOrNull() ?: TuningParams.targetRatio
+            TuningParams.outputWidth = widthEdit.text.toString().toIntOrNull() ?: TuningParams.outputWidth
+            TuningParams.outputHeight = heightEdit.text.toString().toIntOrNull() ?: TuningParams.outputHeight
+            TuningParams.lineHeightPercent = lineHeight.value
+            dialog.dismiss()
+        }
+
+        dialog.show()
+    }
+
+    override fun onRequestPermissionsResult(requestCode: Int, permissions: Array<out String>, grantResults: IntArray) {
+        super.onRequestPermissionsResult(requestCode, permissions, grantResults)
+        if (requestCode == REQUEST_CAMERA_PERMISSION && grantResults.isNotEmpty() && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
+            startCamera()
+        }
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        cameraProvider?.unbindAll()
+        cameraExecutor.shutdown()
+    }
+}

--- a/app/src/main/res/layout/activity_developer.xml
+++ b/app/src/main/res/layout/activity_developer.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:padding="16dp">
+
+    <CheckBox
+        android:id="@+id/debugCheckBox"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Debug mode" />
+
+    <Button
+        android:id="@+id/preprocessButton"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Preprocess Debug" />
+</LinearLayout>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -40,11 +40,12 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent" />
 
-    <CheckBox
-        android:id="@+id/debugCheckBox"
+    <Button
+        android:id="@+id/developerButton"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="Debug mode"
+        android:text="Developer"
+        android:visibility="gone"
         app:layout_constraintTop_toBottomOf="@id/batchCheckBox"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent" />

--- a/app/src/main/res/layout/activity_preprocess_debug.xml
+++ b/app/src/main/res/layout/activity_preprocess_debug.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <ImageView
+        android:id="@+id/processedImage"
+        android:layout_width="match_parent"
+        android:layout_height="200dp"
+        android:scaleType="fitCenter"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
+
+    <FrameLayout
+        android:id="@+id/previewContainer"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        app:layout_constraintTop_toBottomOf="@id/processedImage"
+        app:layout_constraintBottom_toTopOf="@id/captureButton"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent">
+
+        <androidx.camera.view.PreviewView
+            android:id="@+id/viewFinder"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent" />
+
+        <com.example.app.BoundingBoxOverlay
+            android:id="@+id/boundingBox"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent" />
+    </FrameLayout>
+
+    <Button
+        android:id="@+id/captureButton"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Capture"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent" />
+
+    <Button
+        android:id="@+id/tuneButton"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Tune"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/test/java/com/example/app/DeveloperModeTest.kt
+++ b/app/src/test/java/com/example/app/DeveloperModeTest.kt
@@ -1,0 +1,40 @@
+package com.example.app
+
+import android.content.Intent
+import android.view.View
+import android.widget.Button
+import androidx.test.core.app.ApplicationProvider
+import org.junit.Assert.assertEquals
+import org.junit.Ignore
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.shadows.ShadowApplication
+
+@RunWith(RobolectricTestRunner::class)
+class DeveloperModeTest {
+    @Ignore("Robolectric dependencies not available in CI")
+    @Test
+    fun developerPin_showsButton() {
+        val controller = Robolectric.buildActivity(MainActivity::class.java).setup()
+        val activity = controller.get()
+        // allow PIN manually
+        MainActivity::class.java.getDeclaredField("allowedPins").apply { isAccessible = true }.set(activity, setOf("8789"))
+        activity.onPinEntered("8789")
+        val button = activity.findViewById<Button>(R.id.developerButton)
+        assertEquals(View.VISIBLE, button.visibility)
+    }
+
+    @Ignore("Robolectric dependencies not available in CI")
+    @Test
+    fun debugFlag_passedToBinLocator() {
+        val controller = Robolectric.buildActivity(MainActivity::class.java).setup()
+        val activity = controller.get()
+        MainActivity::class.java.getDeclaredField("debugFlag").apply { isAccessible = true }.set(activity, true)
+        val binButton = activity.findViewById<Button>(R.id.binLocatorButton)
+        binButton.performClick()
+        val intent = ShadowApplication.getInstance().nextStartedActivity
+        assertEquals(true, intent.getBooleanExtra("debug", false))
+    }
+}


### PR DESCRIPTION
## Summary
- create a planning document for implementing developer mode and a preprocessing debug module
- record task for generating the PRP
- implement developer mode flag in `MainActivity` and launch new `DeveloperActivity`
- add `PreprocessDebugActivity` for quick preprocessing inspection
- document the new developer workflow

## Testing
- `./gradlew lint testDebugUnitTest`
- `./gradlew connectedDebugAndroidTest` *(fails: PackageDebug task due to missing emulator)*


------
https://chatgpt.com/codex/tasks/task_e_6879d46c96a08328b322dc7cecb5ae2f