### PR TITLE
Add capture preview to Live Edge Preview

### DIFF
--- a/AppFeatures.txt
+++ b/AppFeatures.txt
@@ -39,6 +39,9 @@ The project is a minimal Android application written in Kotlin. Below are all of
 * **Preprocess Debug** captures an image, applies the preprocessing pipeline and displays the result without running OCR.
 * **Live Edge Preview** processes camera frames in real time displaying the edge
   detection result so tuning adjustments update instantly.
+* A **Capture** button saves a photo using the same pipeline as OCR and shows the
+  processed result beneath the live preview for quick inspection.
+* CameraX is configured via an Application class to use only the back camera, preventing initialization errors on devices without a front camera.
 * A **Batch mode** checkbox determines the workflow. When unchecked a full-screen
   bin menu appears automatically once roll and customer are parsed. Selecting a
   value sends the record immediately and the capture and zoom controls are hidden

--- a/TASK.md
+++ b/TASK.md
@@ -50,3 +50,6 @@
 ## [2025-07-20] Generate PRP for Developer Mode and Preprocess Debug - DONE
 ## [2025-07-20] Implement Developer Mode and Preprocess Debug - DONE
 ## [2025-07-20] Add Live Edge Preview for tuning - DONE
+## [2025-07-19] Rotate Canny preview to match orientation - DONE
+## [2025-07-19] Add capture button to Live Edge Preview - DONE
+## [2025-07-20] Fix camera initialization for devices without front camera - DONE

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -6,7 +6,7 @@
     <!-- Allow install on devices without a camera such as Chromebooks -->
     <uses-feature android:name="android.hardware.camera" android:required="false" />
 
-    <application
+    <application android:name=".CamApp"
         android:label="BasicAndroidApp"
         android:theme="@style/Theme.BasicAndroidApp">
         <activity

--- a/app/src/main/java/com/example/app/CamApp.kt
+++ b/app/src/main/java/com/example/app/CamApp.kt
@@ -1,0 +1,19 @@
+package com.example.app
+
+import android.app.Application
+import androidx.camera.camera2.Camera2Config
+import androidx.camera.core.CameraSelector
+import androidx.camera.core.CameraXConfig
+
+/**
+ * Application class providing a CameraX configuration that limits available cameras
+ * to the back camera only. This avoids initialization failures on devices lacking
+ * a front camera.
+ */
+class CamApp : Application(), CameraXConfig.Provider {
+    override fun getCameraXConfig(): CameraXConfig {
+        return CameraXConfig.Builder.fromConfig(Camera2Config.defaultConfig())
+            .setAvailableCamerasLimiter(CameraSelector.DEFAULT_BACK_CAMERA)
+            .build()
+    }
+}

--- a/app/src/main/java/com/example/app/LiveEdgePreviewActivity.kt
+++ b/app/src/main/java/com/example/app/LiveEdgePreviewActivity.kt
@@ -12,17 +12,20 @@ import android.widget.Button
 import android.widget.ImageView
 import androidx.appcompat.app.AppCompatActivity
 import androidx.camera.core.ImageAnalysis
+import androidx.camera.core.ImageCapture
+import androidx.camera.core.ImageCaptureException
 import androidx.camera.core.ImageProxy
 import androidx.camera.lifecycle.ProcessCameraProvider
 import androidx.camera.view.LifecycleCameraController
 import androidx.camera.view.PreviewView
 import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
+import java.io.File
 import org.opencv.android.OpenCVLoader
 import org.opencv.android.Utils
-import org.opencv.core.CvType
 import org.opencv.core.Mat
 import org.opencv.core.Size
+import org.opencv.core.Core
 import org.opencv.imgproc.Imgproc
 import java.io.ByteArrayOutputStream
 import java.util.concurrent.ExecutorService
@@ -35,6 +38,8 @@ class LiveEdgePreviewActivity : AppCompatActivity() {
     private lateinit var previewView: PreviewView
     private lateinit var overlay: BoundingBoxOverlay
     private lateinit var edgeView: ImageView
+    private lateinit var processedImage: ImageView
+    private lateinit var captureButton: Button
     private lateinit var tuneButton: Button
     private lateinit var cameraExecutor: ExecutorService
     private lateinit var controller: LifecycleCameraController
@@ -50,9 +55,13 @@ class LiveEdgePreviewActivity : AppCompatActivity() {
         previewView = findViewById(R.id.viewFinder)
         overlay = findViewById(R.id.boundingBox)
         edgeView = findViewById(R.id.edgeView)
+        processedImage = findViewById(R.id.processedImage)
+        captureButton = findViewById(R.id.captureButton)
         tuneButton = findViewById(R.id.tuneButton)
         cameraExecutor = Executors.newSingleThreadExecutor()
         tuneButton.setOnClickListener { showTuningDialog() }
+        captureButton.setOnClickListener { takePhoto() }
+        captureButton.isEnabled = false
         if (ActivityCompat.checkSelfPermission(this, CAMERA_PERMISSION) == PackageManager.PERMISSION_GRANTED) {
             startCamera()
         } else {
@@ -65,13 +74,21 @@ class LiveEdgePreviewActivity : AppCompatActivity() {
         future.addListener({
             cameraProvider = future.get()
             controller = LifecycleCameraController(this).apply {
-                setEnabledUseCases(LifecycleCameraController.IMAGE_ANALYSIS)
+                setEnabledUseCases(
+                    LifecycleCameraController.IMAGE_ANALYSIS or
+                        LifecycleCameraController.IMAGE_CAPTURE
+                )
+                cameraSelector = androidx.camera.core.CameraSelector.DEFAULT_BACK_CAMERA
                 setImageAnalysisAnalyzer(cameraExecutor, ImageAnalysis.Analyzer { image ->
                     processFrame(image)
                 })
                 bindToLifecycle(this@LiveEdgePreviewActivity)
             }
             previewView.controller = controller
+            controller.initializationFuture.addListener(
+                { captureButton.isEnabled = true },
+                ContextCompat.getMainExecutor(this)
+            )
         }, ContextCompat.getMainExecutor(this))
     }
 
@@ -113,6 +130,7 @@ class LiveEdgePreviewActivity : AppCompatActivity() {
                 )
             }
             Imgproc.cvtColor(mat, mat, Imgproc.COLOR_GRAY2RGBA)
+            Core.rotate(mat, mat, Core.ROTATE_90_CLOCKWISE)
             val result = Bitmap.createBitmap(mat.cols(), mat.rows(), Bitmap.Config.ARGB_8888)
             Utils.matToBitmap(mat, result)
             runOnUiThread { edgeView.setImageBitmap(result) }
@@ -134,6 +152,31 @@ class LiveEdgePreviewActivity : AppCompatActivity() {
         super.onDestroy()
         cameraProvider?.unbindAll()
         cameraExecutor.shutdown()
+    }
+
+    private fun takePhoto() {
+        val photoFile = java.io.File.createTempFile("temp", ".jpg", cacheDir)
+        val options = ImageCapture.OutputFileOptions.Builder(photoFile).build()
+        controller.takePicture(options, cameraExecutor, object : ImageCapture.OnImageSavedCallback {
+            override fun onError(exception: ImageCaptureException) {
+                Log.e("LiveEdgePreview", "capture failed", exception)
+            }
+
+            override fun onImageSaved(output: ImageCapture.OutputFileResults) {
+                val rotated = ImageUtils.decodeRotatedBitmap(photoFile)
+                val crop = overlay.mapToBitmapRect(rotated.width, rotated.height)
+                val cropped = android.graphics.Bitmap.createBitmap(
+                    rotated,
+                    crop.left,
+                    crop.top,
+                    crop.width(),
+                    crop.height()
+                )
+                val warped = LabelCropper.cropLabel(cropped, rotated.width * rotated.height)
+                val processed = ImageUtils.toGrayscale(warped)
+                runOnUiThread { processedImage.setImageBitmap(processed) }
+            }
+        })
     }
 
     private fun showTuningDialog() {

--- a/app/src/main/res/layout/activity_live_edge_preview.xml
+++ b/app/src/main/res/layout/activity_live_edge_preview.xml
@@ -18,7 +18,7 @@
         android:layout_width="0dp"
         android:layout_height="0dp"
         app:layout_constraintTop_toBottomOf="@id/edgeView"
-        app:layout_constraintBottom_toTopOf="@id/tuneButton"
+        app:layout_constraintBottom_toTopOf="@id/processedImage"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent">
 
@@ -32,6 +32,24 @@
             android:layout_width="match_parent"
             android:layout_height="match_parent" />
     </FrameLayout>
+
+    <ImageView
+        android:id="@+id/processedImage"
+        android:layout_width="match_parent"
+        android:layout_height="200dp"
+        android:scaleType="fitCenter"
+        app:layout_constraintTop_toBottomOf="@id/previewContainer"
+        app:layout_constraintBottom_toTopOf="@id/captureButton"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
+
+    <Button
+        android:id="@+id/captureButton"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Capture"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent" />
 
     <Button
         android:id="@+id/tuneButton"


### PR DESCRIPTION
## Summary
- show processed capture image below live preview
- enable capture use case in `LiveEdgePreviewActivity`
- document feature in `AppFeatures.txt` and `TASK.md`
- rotate canny preview to match device orientation
- select back camera explicitly so preview starts
- fix camera initialization on devices without a front camera
- fix preview layout and enable capture after camera initializes

## Testing
- `./gradlew testDebugUnitTest`


------
https://chatgpt.com/codex/tasks/task_e_687b629279108328838152fbb4e40b1c